### PR TITLE
UML-1812 - add bucket policy denying requests not using SSL to access logging bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Enables Guardduty
 | [aws_iam_role_policy_attachment.aws_support_access_for_breakglass](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_s3_account_public_access_block.block_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_account_public_access_block) | resource |
 | [aws_s3_bucket.s3_access_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_policy.s3_access_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.s3_access_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_iam_policy_document.s3_access_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs

--- a/s3_access_logging.tf
+++ b/s3_access_logging.tf
@@ -36,3 +36,32 @@ resource "aws_s3_bucket_public_access_block" "s3_access_logging" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+
+resource "aws_s3_bucket_policy" "s3_access_logging" {
+  bucket = aws_s3_bucket.s3_access_logging.bucket
+  policy = data.aws_iam_policy_document.s3_access_logging.json
+}
+
+data "aws_iam_policy_document" "s3_access_logging" {
+  statement {
+    sid     = "DenyNoneSSLRequests"
+    effect  = "Deny"
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.s3_access_logging.arn,
+      "${aws_s3_bucket.s3_access_logging.arn}/*"
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = [false]
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+}


### PR DESCRIPTION
https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-s3-5