### PR TITLE
UML-1987 - attach managed roles for inspector2 to operator, breakglass and ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Enables Guardduty
 | [aws_iam_account_password_policy.strict](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy) | resource |
 | [aws_iam_role_policy_attachment.aws_inspector2_access_for_breakglass](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.aws_inspector2_access_for_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.aws_inspector2_access_for_operator](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.aws_support_access_for_breakglass](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_s3_account_public_access_block.block_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_account_public_access_block) | resource |
 | [aws_s3_bucket.s3_access_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Enables Guardduty
 | [aws_ebs_encryption_by_default.enabled](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_encryption_by_default) | resource |
 | [aws_guardduty_detector.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_detector) | resource |
 | [aws_iam_account_password_policy.strict](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy) | resource |
+| [aws_iam_role_policy_attachment.aws_inspector2_access_for_breakglass](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.aws_inspector2_access_for_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.aws_support_access_for_breakglass](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_s3_account_public_access_block.block_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_account_public_access_block) | resource |
 | [aws_s3_bucket.s3_access_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |

--- a/roles.tf
+++ b/roles.tf
@@ -23,6 +23,11 @@ module "operator" {
   create_instance_profile = var.operator_create_instance_profile
 }
 
+resource "aws_iam_role_policy_attachment" "aws_inspector2_access_for_breakglass" {
+  role       = module.operator.aws_iam_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2FullAccess"
+}
+
 module "breakglass" {
   source                  = "./default_roles"
   name                    = "breakglass"
@@ -37,10 +42,20 @@ resource "aws_iam_role_policy_attachment" "aws_support_access_for_breakglass" {
   policy_arn = "arn:aws:iam::aws:policy/AWSSupportAccess"
 }
 
+resource "aws_iam_role_policy_attachment" "aws_inspector2_access_for_breakglass" {
+  role       = module.breakglass.aws_iam_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2FullAccess"
+}
+
 module "ci" {
   source             = "./default_roles"
   name               = "${var.product}-ci"
   user_arns          = var.user_arns.ci
   base_policy_arn    = var.ci_base_policy_arn
   custom_policy_json = var.ci_custom_policy_json
+}
+
+resource "aws_iam_role_policy_attachment" "aws_inspector2_access_for_ci" {
+  role       = module.ci.aws_iam_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2FullAccess"
 }

--- a/roles.tf
+++ b/roles.tf
@@ -23,7 +23,7 @@ module "operator" {
   create_instance_profile = var.operator_create_instance_profile
 }
 
-resource "aws_iam_role_policy_attachment" "aws_inspector2_access_for_breakglass" {
+resource "aws_iam_role_policy_attachment" "aws_inspector2_access_for_operator" {
   role       = module.operator.aws_iam_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2FullAccess"
 }


### PR DESCRIPTION
# Purpose

attach managed roles for inspector2 to account module default roles (operator, breakglass and ci)