### PR TITLE
MLPAB-132 - Create AWS Cost Explorer anomaly detection #major

### DIFF
--- a/cost_anomoly_detection.tf
+++ b/cost_anomoly_detection.tf
@@ -1,9 +1,9 @@
 
 module "cost_anomaly_detection_development" {
-  source                     = "./modules/ce_anomoly_detection"
-  notification_email_address = var.cost_anomaly_notification_email_address
-  weekly_schedule_threshold  = var.cost_anomaly_weekly_schedule_threshold
-  daily_schedule_threshold   = var.cost_anomaly_weekly_schedule_threshold
+  source                       = "./modules/ce_anomoly_detection"
+  notification_email_address   = var.cost_anomaly_notification_email_address
+  weekly_schedule_threshold    = var.cost_anomaly_weekly_schedule_threshold
+  immediate_schedule_threshold = var.cost_anomaly_immediate_schedule_threshold
   providers = {
     aws.global = aws.global
   }

--- a/cost_anomoly_detection.tf
+++ b/cost_anomoly_detection.tf
@@ -1,0 +1,10 @@
+
+module "cost_anomaly_detection_development" {
+  source                     = "./modules/ce_anomoly_detection"
+  notification_email_address = var.cost_anomaly_notification_email_address
+  weekly_schedule_threshold  = var.cost_anomaly_weekly_schedule_threshold
+  daily_schedule_threshold   = var.cost_anomaly_weekly_schedule_threshold
+  providers = {
+    aws.global = aws.global
+  }
+}

--- a/modules/ce_anomoly_detection/main.tf
+++ b/modules/ce_anomoly_detection/main.tf
@@ -25,10 +25,10 @@ resource "aws_ce_anomaly_subscription" "weekly" {
   provider = aws.global
 }
 
-resource "aws_ce_anomaly_subscription" "daily" {
-  name      = "Daily Subscription"
-  threshold = var.daily_schedule_threshold
-  frequency = "DAILY"
+resource "aws_ce_anomaly_subscription" "immediate" {
+  name      = "Immediate Subscription"
+  threshold = var.immediate_schedule_threshold
+  frequency = "IMMEDIATE"
 
   monitor_arn_list = [
     aws_ce_anomaly_monitor.service_monitor.arn,
@@ -36,7 +36,7 @@ resource "aws_ce_anomaly_subscription" "daily" {
 
   subscriber {
     type    = "SNS"
-    address = aws_sns_topic.daily_cost_anomaly_updates.arn
+    address = aws_sns_topic.immediate_cost_anomaly_updates.arn
   }
 
   depends_on = [
@@ -45,8 +45,8 @@ resource "aws_ce_anomaly_subscription" "daily" {
   provider = aws.global
 }
 
-resource "aws_sns_topic" "daily_cost_anomaly_updates" {
-  name     = "DailyCostAnomalyUpdates"
+resource "aws_sns_topic" "immediate_cost_anomaly_updates" {
+  name     = "immediateCostAnomalyUpdates"
   provider = aws.global
 }
 
@@ -68,7 +68,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
     }
 
     resources = [
-      aws_sns_topic.daily_cost_anomaly_updates.arn,
+      aws_sns_topic.immediate_cost_anomaly_updates.arn,
     ]
   }
 
@@ -104,14 +104,14 @@ data "aws_iam_policy_document" "sns_topic_policy" {
     }
 
     resources = [
-      aws_sns_topic.daily_cost_anomaly_updates.arn,
+      aws_sns_topic.immediate_cost_anomaly_updates.arn,
     ]
   }
   provider = aws.global
 }
 
 resource "aws_sns_topic_policy" "default" {
-  arn      = aws_sns_topic.daily_cost_anomaly_updates.arn
+  arn      = aws_sns_topic.immediate_cost_anomaly_updates.arn
   policy   = data.aws_iam_policy_document.sns_topic_policy.json
   provider = aws.global
 }

--- a/modules/ce_anomoly_detection/main.tf
+++ b/modules/ce_anomoly_detection/main.tf
@@ -1,0 +1,117 @@
+data "aws_caller_identity" "current" {
+  provider = aws.global
+}
+
+resource "aws_ce_anomaly_monitor" "service_monitor" {
+  name              = "AWSServiceMonitor"
+  monitor_type      = "DIMENSIONAL"
+  monitor_dimension = "SERVICE"
+  provider          = aws.global
+}
+
+resource "aws_ce_anomaly_subscription" "weekly" {
+  name      = "Weekly Subscription"
+  threshold = var.weekly_schedule_threshold
+  frequency = "WEEKLY"
+
+  monitor_arn_list = [
+    aws_ce_anomaly_monitor.service_monitor.arn,
+  ]
+
+  subscriber {
+    type    = "EMAIL"
+    address = var.notification_email_address
+  }
+  provider = aws.global
+}
+
+resource "aws_ce_anomaly_subscription" "daily" {
+  name      = "Daily Subscription"
+  threshold = var.daily_schedule_threshold
+  frequency = "DAILY"
+
+  monitor_arn_list = [
+    aws_ce_anomaly_monitor.service_monitor.arn,
+  ]
+
+  subscriber {
+    type    = "SNS"
+    address = aws_sns_topic.daily_cost_anomaly_updates.arn
+  }
+
+  depends_on = [
+    aws_sns_topic_policy.default,
+  ]
+  provider = aws.global
+}
+
+resource "aws_sns_topic" "daily_cost_anomaly_updates" {
+  name     = "DailyCostAnomalyUpdates"
+  provider = aws.global
+}
+
+data "aws_iam_policy_document" "sns_topic_policy" {
+  policy_id = "__default_policy_ID"
+
+  statement {
+    sid = "AWSAnomalyDetectionSNSPublishingPermissions"
+
+    actions = [
+      "SNS:Publish",
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["costalerts.amazonaws.com"]
+    }
+
+    resources = [
+      aws_sns_topic.daily_cost_anomaly_updates.arn,
+    ]
+  }
+
+  statement {
+    sid = "__default_statement_ID"
+
+    actions = [
+      "SNS:Subscribe",
+      "SNS:SetTopicAttributes",
+      "SNS:RemovePermission",
+      "SNS:Receive",
+      "SNS:Publish",
+      "SNS:ListSubscriptionsByTopic",
+      "SNS:GetTopicAttributes",
+      "SNS:DeleteTopic",
+      "SNS:AddPermission",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceOwner"
+
+      values = [
+        data.aws_caller_identity.current.account_id,
+      ]
+    }
+
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    resources = [
+      aws_sns_topic.daily_cost_anomaly_updates.arn,
+    ]
+  }
+  provider = aws.global
+}
+
+resource "aws_sns_topic_policy" "default" {
+  arn      = aws_sns_topic.daily_cost_anomaly_updates.arn
+  policy   = data.aws_iam_policy_document.sns_topic_policy.json
+  provider = aws.global
+}

--- a/modules/ce_anomoly_detection/outputs.tf
+++ b/modules/ce_anomoly_detection/outputs.tf
@@ -1,0 +1,3 @@
+output "daily_schedule_sns_topic" {
+  value = aws_sns_topic.daily_cost_anomaly_updates
+}

--- a/modules/ce_anomoly_detection/outputs.tf
+++ b/modules/ce_anomoly_detection/outputs.tf
@@ -1,3 +1,3 @@
-output "daily_schedule_sns_topic" {
-  value = aws_sns_topic.daily_cost_anomaly_updates
+output "immediate_schedule_sns_topic" {
+  value = aws_sns_topic.immediate_cost_anomaly_updates
 }

--- a/modules/ce_anomoly_detection/terraform.tf
+++ b/modules/ce_anomoly_detection/terraform.tf
@@ -1,15 +1,12 @@
 terraform {
-  required_version = ">= 1.1.5"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 4.9.0"
       configuration_aliases = [
-        aws.eu-west-2,
         aws.global,
       ]
     }
   }
+  required_version = ">= 1.0.0"
 }
-
-data "aws_region" "current" {}

--- a/modules/ce_anomoly_detection/variables.tf
+++ b/modules/ce_anomoly_detection/variables.tf
@@ -9,8 +9,8 @@ variable "weekly_schedule_threshold" {
   description = "The dollar value that triggers a weekly notification if the threshold is exceeded."
 }
 
-variable "daily_schedule_threshold" {
+variable "immediate_schedule_threshold" {
   type        = number
   default     = 10
-  description = "The dollar value that triggers a daily notification if the threshold is exceeded."
+  description = "The dollar value that triggers an immediate notification if the threshold is exceeded."
 }

--- a/modules/ce_anomoly_detection/variables.tf
+++ b/modules/ce_anomoly_detection/variables.tf
@@ -5,12 +5,10 @@ variable "notification_email_address" {
 
 variable "weekly_schedule_threshold" {
   type        = number
-  default     = 100
   description = "The dollar value that triggers a weekly notification if the threshold is exceeded."
 }
 
 variable "immediate_schedule_threshold" {
   type        = number
-  default     = 10
   description = "The dollar value that triggers an immediate notification if the threshold is exceeded."
 }

--- a/modules/ce_anomoly_detection/variables.tf
+++ b/modules/ce_anomoly_detection/variables.tf
@@ -1,0 +1,16 @@
+variable "notification_email_address" {
+  type        = string
+  description = "Email address to use to send anomaly alerts to"
+}
+
+variable "weekly_schedule_threshold" {
+  type        = number
+  default     = 100
+  description = "The dollar value that triggers a weekly notification if the threshold is exceeded."
+}
+
+variable "daily_schedule_threshold" {
+  type        = number
+  default     = 10
+  description = "The dollar value that triggers a daily notification if the threshold is exceeded."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -202,3 +202,20 @@ variable "fsbp_standard_control_elb_6_enabled" {
   default     = true
   description = "When false, sets standard control to disabled."
 }
+
+variable "cost_anomaly_notification_email_address" {
+  type        = string
+  description = "Email address to use to send anomaly alerts to"
+}
+
+variable "cost_anomaly_weekly_schedule_threshold" {
+  type        = number
+  default     = 100
+  description = "The dollar value that triggers a weekly notification if the threshold is exceeded."
+}
+
+variable "cost_anomaly_daily_schedule_threshold" {
+  type        = number
+  default     = 10
+  description = "The dollar value that triggers a daily notification if the threshold is exceeded."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -214,8 +214,8 @@ variable "cost_anomaly_weekly_schedule_threshold" {
   description = "The dollar value that triggers a weekly notification if the threshold is exceeded."
 }
 
-variable "cost_anomaly_daily_schedule_threshold" {
+variable "cost_anomaly_immediate_schedule_threshold" {
   type        = number
   default     = 10
-  description = "The dollar value that triggers a daily notification if the threshold is exceeded."
+  description = "The dollar value that triggers an immediate notification if the threshold is exceeded."
 }


### PR DESCRIPTION
# Purpose

Notify team when unexpected costs occur

Fixes MLPAB-132

## Approach

- Create a module to set up cost anomaly detection
- Configure weekly email notifications to the team
- Configure SNS daily alerts for alerting
- Requires an upgrade of the terraform aws provider to v4
- Requires a new global (us-east-1) provider

## Learning

Note:
Creating AWS CE (Cost Explorer) Anomaly Subscription (): ValidationException: Daily or weekly frequencies only support Email subscriptions

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ce_anomaly_monitor
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ce_anomaly_subscription
