### PR TITLE
MLPAB-239 - Fix rule name length error

### DIFF
--- a/modules/config/sns.tf
+++ b/modules/config/sns.tf
@@ -1,5 +1,5 @@
 resource "aws_sns_topic" "config" {
-  name              = local.config_name
+  name              = "aws-config-${local.config_name}"
   kms_master_key_id = aws_kms_key.config_sns.key_id
 }
 

--- a/modules/config/variables.tf
+++ b/modules/config/variables.tf
@@ -27,5 +27,5 @@ variable "product" {
 }
 
 locals {
-  config_name = "aws-config-${var.product}-${var.account_name}"
+  config_name = "${var.product}-${var.account_name}"
 }


### PR DESCRIPTION
# Purpose

AWS Config rule names are limited to 64 characters.

`Error: expected length of name to be in the range (0 - 64), got ...`

the local used includes `aws-config` which is superfluous due to it being used mostly with AWS Config resources. There is one exception which is where it's used for the SNS topic name for AWS Config.

Removing `aws-config` from the local leaves more space for longer product names

Fixes MLPAB-239

## Approach

- remove aws-config from config_name as its only used in the conftext of aws config resources
- add `aws-config` to SNS topic name