### PR TITLE
MLPAB-282 - Add S3 bucket server access logging to config bucket

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,20 +2,21 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.70.0"
-  constraints = ">= 3.59.0"
+  version     = "4.34.0"
+  constraints = ">= 3.59.0, >= 4.9.0"
   hashes = [
-    "h1:jn4ImGMZJ9rQdaVSbcCBqUqnhRSpyaM1DivqaNuP+eg=",
-    "zh:0af710e528e21b930899f0ac295b0ceef8ad7b623dd8f38e92c8ec4bc7af0321",
-    "zh:4cabcd4519c0aae474d91ae67a8e3a4a8c39c3945c289a9cf7c1409f64409abe",
-    "zh:58da1a436facb4e4f95cd2870d211ed7bcb8cf721a4a61970aa8da191665f2aa",
-    "zh:6465339475c1cd3c16a5c8fee61304dcad2c4a27740687d29c6cdc90d2e6423d",
-    "zh:7a821ed053c355d70ebe33185590953fa5c364c1f3d66fe3f9b4aba3961646b1",
-    "zh:7c3656cc9cc1739dcb298e7930c9a76ccfce738d2070841d7e6c62fbdae74eef",
-    "zh:9d9da9e3c60a0c977e156da8590f36a219ae91994bb3df5a1208de2ab3ceeba7",
-    "zh:a3138817c86bf3e4dca7fd3a92e099cd1bf1d45ee7c7cc9e9773ba04fc3b315a",
-    "zh:a8603044e935dfb3cb9319a46d26276162c6aea75e02c4827232f9c6029a3182",
-    "zh:aef9482332bf43d0b73317f5909dec9e95b983c67b10d72e75eacc7c4f37d084",
-    "zh:fc3f3cad84f2eebe566dd0b65904c934093007323b9b85e73d9dd4535ceeb29d",
+    "h1:SDqaa/BVMQMzQ1bWQfrcsC4jfaywFeUq03jsojDNnyY=",
+    "zh:2bdc9b908008c1e874d8ba7e2cfabd856cafb63c52fef51a1fdeef2f5584bffd",
+    "zh:43c5364e3161be3856e56494cbb8b21d513fc05875f1b40e66e583602154dd0a",
+    "zh:44e763adae92489f223f65866c1f8b5342e7e85b95daa8d1f483a2afb47f7db3",
+    "zh:62bfabb3a1a31814cb3fadc356539d8253b95abacfffd90984affb54c9a53a86",
+    "zh:6495ce67897d2d5648d466c09e8588e837c2878322988738a95c06926044b05d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b1546b2ac61d7cc27a8eba160ae1b6ac581d2c4af824a400d6511e4998da398a",
+    "zh:c8c362c5527f0533bde581e41cdb2bdf42aea557762f326dbfa122fdf001fb10",
+    "zh:c8cc28fb41f73ca09f590bace2204ea325f6116be0bbce6abfebd393d028f12c",
+    "zh:db0601c9bd12ca028d60ac87e85320285ebc64857715f7908dd6a283e5f44d45",
+    "zh:e64d2193236d05348ba2e8b99650d9274e5af80be39b3ee28bbe442b0684d8a3",
+    "zh:ff6228f3751e1f0ee7dc086d09e32d39ca6556f0b5267f36aae67881d29ace94",
   ]
 }

--- a/modules/config/s3.tf
+++ b/modules/config/s3.tf
@@ -4,6 +4,10 @@ resource "aws_s3_bucket" "config" {
   bucket        = "config.${data.aws_region.current.name}.${var.account_name}.${var.product}.opg.justice.gov.uk"
   acl           = "private"
   force_destroy = true
+  logging {
+    target_bucket = var.s3_access_logging_bucket_name
+    target_prefix = "log/${var.bucket_name}/"
+  }
 
   versioning {
     enabled = true

--- a/modules/config/s3.tf
+++ b/modules/config/s3.tf
@@ -4,6 +4,7 @@ resource "aws_s3_bucket" "config" {
   bucket        = "config.${data.aws_region.current.name}.${var.account_name}.${var.product}.opg.justice.gov.uk"
   acl           = "private"
   force_destroy = true
+
   logging {
     target_bucket = var.s3_access_logging_bucket_name
     target_prefix = "log/config.${data.aws_region.current.name}.${var.account_name}.${var.product}.opg.justice.gov.uk/"

--- a/modules/config/s3.tf
+++ b/modules/config/s3.tf
@@ -6,7 +6,7 @@ resource "aws_s3_bucket" "config" {
   force_destroy = true
   logging {
     target_bucket = var.s3_access_logging_bucket_name
-    target_prefix = "log/${var.bucket_name}/"
+    target_prefix = "log/config.${data.aws_region.current.name}.${var.account_name}.${var.product}.opg.justice.gov.uk/"
   }
 
   versioning {

--- a/modules/config/s3.tf
+++ b/modules/config/s3.tf
@@ -9,7 +9,6 @@ resource "aws_s3_bucket" "config" {
     target_bucket = var.s3_access_logging_bucket_name
     target_prefix = "log/config.${data.aws_region.current.name}.${var.account_name}.${var.product}.opg.justice.gov.uk/"
   }
-
   versioning {
     enabled = true
   }

--- a/modules/config/variables.tf
+++ b/modules/config/variables.tf
@@ -29,3 +29,8 @@ variable "product" {
 locals {
   config_name = "${var.product}-${var.account_name}"
 }
+
+variable "s3_access_logging_bucket_name" {
+  description = "The name of the bucket that will receive the log objects"
+  type        = string
+}

--- a/modules/region/config.tf
+++ b/modules/region/config.tf
@@ -1,7 +1,8 @@
 module "aws_config" {
-  source          = "../config"
-  count           = var.baseline_security_enabled ? 1 : 0
-  account_name    = var.account_name
-  config_iam_role = var.config_iam_role
-  product         = var.product
+  source                        = "../config"
+  count                         = var.baseline_security_enabled ? 1 : 0
+  account_name                  = var.account_name
+  config_iam_role               = var.config_iam_role
+  s3_access_logging_bucket_name = aws_s3_bucket.s3_access_logging.id
+  product                       = var.product
 }


### PR DESCRIPTION
# Purpose

Server access logging provides detailed records of requests made to a bucket. Server access logs can assist in security and access audits. For more information, see [Security Best Practices for Amazon S3: Enable Amazon S3 server access logging](https://docs.aws.amazon.com/AmazonS3/latest/dev/security-best-practices.html).

# Approach

- Add logging to the access logging bucket for config s3 bucket

