### PR TITLE
MLPAB-533 - rename AWS Config bucket #major

### DIFF
--- a/modules/config/s3.tf
+++ b/modules/config/s3.tf
@@ -1,13 +1,13 @@
 data "aws_region" "current" {}
 
 resource "aws_s3_bucket" "config" {
-  bucket        = "config.${data.aws_region.current.name}.${var.account_name}.${var.product}.opg.justice.gov.uk"
+  bucket        = "config-${data.aws_region.current.name}-${var.account_name}-${var.product}-opg"
   acl           = "private"
   force_destroy = true
 
   logging {
     target_bucket = var.s3_access_logging_bucket_name
-    target_prefix = "log/config.${data.aws_region.current.name}.${var.account_name}.${var.product}.opg.justice.gov.uk/"
+    target_prefix = "log/config-${data.aws_region.current.name}-${var.account_name}-${var.product}-opg"
   }
   versioning {
     enabled = true


### PR DESCRIPTION
# Purpose

The current naming convention used for AWS Config S3 buckets prevents the use of the proproduction account's name in full due to using a fully qualified domain name (FQDN) format. This format contradicts best practice guidelines from AWS on S3 bucket naming. [See ADR 0004 on org infra](https://github.com/ministryofjustice/opg-org-infra/blob/main/docs/architecture/decisions/0004-s3-bucket-naming-for-best-compatability.md).

# Approach

- rename AWS Config S3 bucket to match the format `<aws_service/opg_function>-<aws_region_name>-<account_name>-<product_name>-opg`

# Notes

This is a major upgrade as renaming S3 buckets is destroy/create process.

The recommendation is that when upgrading to this version, run a `terraform state rm` operation on the existing S3 bucket to remove it from terraform management and create the new bucket alongside it.

Lifecycle policies on the old bucket will maintain retention windows and remove old objects as they expire. The empty bucket can then be deleted 400 days after upgrading.

For example, for the mlpab development account

```shell
tf state rm 'module.development.module.eu-west-1.module.aws_config[0].aws_s3_bucket.config'
tf state rm 'module.development.module.eu-west-1.module.aws_config[0].aws_s3_bucket_policy.config_bucket'
tf state rm 'module.development.module.eu-west-1.module.aws_config[0].aws_s3_bucket_public_access_block.config'

tf state rm 'module.development.module.eu-west-2.module.aws_config[0].aws_s3_bucket.config'
tf state rm 'module.development.module.eu-west-2.module.aws_config[0].aws_s3_bucket_policy.config_bucket'
tf state rm 'module.development.module.eu-west-2.module.aws_config[0].aws_s3_bucket_public_access_block.config'
```

These resources can all be imported with the bucket name if you need to restore the previous configuration