### PR TITLE
MLPAB-560 - Enable rate limit and error limit insights for AWS Cloudtrail

### DIFF
--- a/modules/cloudtrail/cloudtrail.tf
+++ b/modules/cloudtrail/cloudtrail.tf
@@ -22,6 +22,13 @@ resource "aws_cloudtrail" "cloudtrail" {
       values = ["arn:aws:lambda"]
     }
   }
+  insight_selector {
+    insight_type = "ApiCallRateInsight"
+  }
+
+  insight_selector {
+    insight_type = "ApiErrorRateInsight"
+  }
 }
 
 resource "aws_cloudwatch_log_group" "cloudtrail" {


### PR DESCRIPTION
# Purpose

Use AWS Cloudtrail insights to detect unusual API or error rate activity

Fixes MLPAB-560

## Approach

- Add both insight selectors cloudtrail

## Learning

- https://docs.aws.amazon.com/awscloudtrail/latest/userguide/view-insights-events-console.html
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail#insight_selector
- https://aws.amazon.com/cloudtrail/pricing/

## Checklist

* [x] I have performed a self-review of my own code