### PR TITLE
MLPAB-615 - Fix dependency issue between security hub and cloudtrail modules

### DIFF
--- a/modules/cloudtrail/output.tf
+++ b/modules/cloudtrail/output.tf
@@ -1,0 +1,3 @@
+output "cloudtrail_log_group_name" {
+  value = aws_cloudwatch_log_group.cloudtrail.name
+}

--- a/modules/security_hub/cis_foundation_controls.tf
+++ b/modules/security_hub/cis_foundation_controls.tf
@@ -154,7 +154,7 @@ resource "aws_cloudwatch_log_metric_filter" "toggled_control" {
   for_each       = local.cis_controls
   name           = each.value.metric_name
   pattern        = each.value.pattern
-  log_group_name = data.aws_cloudwatch_log_group.cloudtrail.name
+  log_group_name = var.aws_cloudwatch_log_group_cloudtrail_name
   metric_transformation {
     name      = each.value.metric_name
     namespace = "CISLogMetrics"

--- a/modules/security_hub/main.tf
+++ b/modules/security_hub/main.tf
@@ -1,9 +1,5 @@
 resource "aws_securityhub_account" "main" {}
 
-data "aws_cloudwatch_log_group" "cloudtrail" {
-  name = var.aws_cloudwatch_log_group_cloudtrail_name
-}
-
 data "aws_caller_identity" "current" {
 }
 

--- a/security_hub.tf
+++ b/security_hub.tf
@@ -4,7 +4,7 @@ module "security_hub" {
   account_name                              = var.account_name
   product                                   = var.product
   cis_metric_namespace                      = var.cis_metric_namespace
-  aws_cloudwatch_log_group_cloudtrail_name  = var.cloudtrail_trail_name
+  aws_cloudwatch_log_group_cloudtrail_name  = module.cloudtrail.cloudtrail_log_group_name
   cis_foundation_control_1_14_enabled       = var.cis_foundation_control_1_14_enabled
   cis_foundation_control_3_4_enabled        = var.cis_foundation_control_3_4_enabled
   cis_foundation_control_3_8_enabled        = var.cis_foundation_control_3_8_enabled


### PR DESCRIPTION
When implementing the module for the first time, planning fails because there is no resource dependency created between securityhub and cloudtrail. The former requires the latter's log group. 

Using an output from the cloudtrail module to provide the log group name should resolve this.

- output the cloudtrail log group name from the cloudtrail module
- use cloudtrail module output as securityhub input
- remove data source