### PR TITLE
MLPAB-972 - add name to policies created for the default roles

### DIFF
--- a/modules/default_roles/main.tf
+++ b/modules/default_roles/main.tf
@@ -68,6 +68,7 @@ resource "aws_iam_role_policy_attachment" "base" {
 }
 
 resource "aws_iam_role_policy" "custom" {
+  name   = var.name
   policy = var.custom_policy_json != "" ? var.custom_policy_json : data.aws_iam_policy_document.default.json
   role   = aws_iam_role.role.id
 }


### PR DESCRIPTION
Adding name to policies in order to be able to reference them in SSO setup

![image](https://github.com/ministryofjustice/opg-terraform-aws-account/assets/6545556/8b3ceb4b-cb07-4d21-aa96-177a3a9af559)
