### PR TITLE
Update security hub account for >= v4.60

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,21 +2,24 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "4.34.0"
-  constraints = ">= 3.59.0, >= 4.9.0"
+  version     = "4.67.0"
+  constraints = ">= 3.59.0, ~> 4.0, >= 4.7.0, >= 4.9.0"
   hashes = [
-    "h1:SDqaa/BVMQMzQ1bWQfrcsC4jfaywFeUq03jsojDNnyY=",
-    "zh:2bdc9b908008c1e874d8ba7e2cfabd856cafb63c52fef51a1fdeef2f5584bffd",
-    "zh:43c5364e3161be3856e56494cbb8b21d513fc05875f1b40e66e583602154dd0a",
-    "zh:44e763adae92489f223f65866c1f8b5342e7e85b95daa8d1f483a2afb47f7db3",
-    "zh:62bfabb3a1a31814cb3fadc356539d8253b95abacfffd90984affb54c9a53a86",
-    "zh:6495ce67897d2d5648d466c09e8588e837c2878322988738a95c06926044b05d",
+    "h1:5Zfo3GfRSWBaXs4TGQNOflr1XaYj6pRnVJLX5VAjFX4=",
+    "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
+    "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
+    "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
+    "zh:4a002990b9f4d6d225d82cb2fb8805789ffef791999ee5d9cb1fef579aeff8f1",
+    "zh:559a2b5ace06b878c6de3ecf19b94fbae3512562f7a51e930674b16c2f606e29",
+    "zh:6a07da13b86b9753b95d4d8218f6dae874cf34699bca1470d6effbb4dee7f4b7",
+    "zh:768b3bfd126c3b77dc975c7c0e5db3207e4f9997cf41aa3385c63206242ba043",
+    "zh:7be5177e698d4b547083cc738b977742d70ed68487ce6f49ecd0c94dbf9d1362",
+    "zh:8b562a818915fb0d85959257095251a05c76f3467caa3ba95c583ba5fe043f9b",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:b1546b2ac61d7cc27a8eba160ae1b6ac581d2c4af824a400d6511e4998da398a",
-    "zh:c8c362c5527f0533bde581e41cdb2bdf42aea557762f326dbfa122fdf001fb10",
-    "zh:c8cc28fb41f73ca09f590bace2204ea325f6116be0bbce6abfebd393d028f12c",
-    "zh:db0601c9bd12ca028d60ac87e85320285ebc64857715f7908dd6a283e5f44d45",
-    "zh:e64d2193236d05348ba2e8b99650d9274e5af80be39b3ee28bbe442b0684d8a3",
-    "zh:ff6228f3751e1f0ee7dc086d09e32d39ca6556f0b5267f36aae67881d29ace94",
+    "zh:9c385d03a958b54e2afd5279cd8c7cbdd2d6ca5c7d6a333e61092331f38af7cf",
+    "zh:b3ca45f2821a89af417787df8289cb4314b273d29555ad3b2a5ab98bb4816b3b",
+    "zh:da3c317f1db2469615ab40aa6baba63b5643bae7110ff855277a1fb9d8eb4f2c",
+    "zh:dc6430622a8dc5cdab359a8704aec81d3825ea1d305bbb3bbd032b1c6adfae0c",
+    "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
   ]
 }

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Enables Guardduty
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_name"></a> [account\_name](#input\_account\_name) | Account Name | `string` | `""` | no |
+| <a name="input_auto_enable_controls"></a> [auto\_enable\_controls](#input\_auto\_enable\_controls) | Whether to automatically enable new controls when they are added to standards that are enabled | `bool` | `false` | no |
 | <a name="input_aws_config_enabled"></a> [aws\_config\_enabled](#input\_aws\_config\_enabled) | n/a | `bool` | `false` | no |
 | <a name="input_aws_s3_account_block_public_access_enable"></a> [aws\_s3\_account\_block\_public\_access\_enable](#input\_aws\_s3\_account\_block\_public\_access\_enable) | Whether Amazon S3 should enable public blocks for buckets in this account. Defaults to False. | `bool` | `false` | no |
 | <a name="input_aws_s3_account_block_public_acls"></a> [aws\_s3\_account\_block\_public\_acls](#input\_aws\_s3\_account\_block\_public\_acls) | Whether Amazon S3 should block public ACLs for buckets in this account. Defaults to true. | `bool` | `true` | no |
@@ -106,10 +107,12 @@ Enables Guardduty
 | <a name="input_cis_metric_namespace"></a> [cis\_metric\_namespace](#input\_cis\_metric\_namespace) | The destination namespace of the CIS CloudWatch metric. | `string` | `"CISLogMetrics"` | no |
 | <a name="input_cloudtrail_bucket_name"></a> [cloudtrail\_bucket\_name](#input\_cloudtrail\_bucket\_name) | trail name | `string` | `"cloudtrail"` | no |
 | <a name="input_cloudtrail_trail_name"></a> [cloudtrail\_trail\_name](#input\_cloudtrail\_trail\_name) | trail name | `string` | `"cloudtrail"` | no |
+| <a name="input_control_finding_generator"></a> [control\_finding\_generator](#input\_control\_finding\_generator) | Updates whether the calling account has consolidated control findings turned on | `string` | `"STANDARD_CONTROL"` | no |
 | <a name="input_cost_anomaly_immediate_schedule_threshold"></a> [cost\_anomaly\_immediate\_schedule\_threshold](#input\_cost\_anomaly\_immediate\_schedule\_threshold) | The dollar value that triggers an immediate notification if the threshold is exceeded. | `number` | `10` | no |
 | <a name="input_cost_anomaly_notification_email_address"></a> [cost\_anomaly\_notification\_email\_address](#input\_cost\_anomaly\_notification\_email\_address) | Email address to use to send anomaly alerts to | `string` | `null` | no |
 | <a name="input_cost_anomaly_weekly_schedule_threshold"></a> [cost\_anomaly\_weekly\_schedule\_threshold](#input\_cost\_anomaly\_weekly\_schedule\_threshold) | The dollar value that triggers a weekly notification if the threshold is exceeded. | `number` | `100` | no |
 | <a name="input_custom_alarms_breakglass_login_alarm_enabled"></a> [custom\_alarms\_breakglass\_login\_alarm\_enabled](#input\_custom\_alarms\_breakglass\_login\_alarm\_enabled) | Enable or disable the breakglass login alarm | `bool` | `true` | no |
+| <a name="input_enable_default_standards"></a> [enable\_default\_standards](#input\_enable\_default\_standards) | Whether to enable the security standards that Security Hub has designated as automatically enabled | `bool` | `false` | no |
 | <a name="input_enable_guardduty"></a> [enable\_guardduty](#input\_enable\_guardduty) | n/a | `bool` | `true` | no |
 | <a name="input_fsbp_standard_control_elb_6_enabled"></a> [fsbp\_standard\_control\_elb\_6\_enabled](#input\_fsbp\_standard\_control\_elb\_6\_enabled) | When false, sets standard control to disabled. | `bool` | `true` | no |
 | <a name="input_is_production"></a> [is\_production](#input\_is\_production) | n/a | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ Enables Guardduty
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.34.0 |
-| <a name="provider_aws.global"></a> [aws.global](#provider\_aws.global) | 4.34.0 |
-| <a name="provider_aws.management"></a> [aws.management](#provider\_aws.management) | 4.34.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
+| <a name="provider_aws.global"></a> [aws.global](#provider\_aws.global) | 4.67.0 |
+| <a name="provider_aws.management"></a> [aws.management](#provider\_aws.management) | 4.67.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Enables Guardduty
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_name"></a> [account\_name](#input\_account\_name) | Account Name | `string` | `""` | no |
-| <a name="input_auto_enable_controls"></a> [auto\_enable\_controls](#input\_auto\_enable\_controls) | Whether to automatically enable new controls when they are added to standards that are enabled | `bool` | `false` | no |
+| <a name="input_auto_enable_controls"></a> [auto\_enable\_controls](#input\_auto\_enable\_controls) | Whether to automatically enable new controls when they are added to standards that are enabled | `bool` | `true` | no |
 | <a name="input_aws_config_enabled"></a> [aws\_config\_enabled](#input\_aws\_config\_enabled) | n/a | `bool` | `false` | no |
 | <a name="input_aws_s3_account_block_public_access_enable"></a> [aws\_s3\_account\_block\_public\_access\_enable](#input\_aws\_s3\_account\_block\_public\_access\_enable) | Whether Amazon S3 should enable public blocks for buckets in this account. Defaults to False. | `bool` | `false` | no |
 | <a name="input_aws_s3_account_block_public_acls"></a> [aws\_s3\_account\_block\_public\_acls](#input\_aws\_s3\_account\_block\_public\_acls) | Whether Amazon S3 should block public ACLs for buckets in this account. Defaults to true. | `bool` | `true` | no |

--- a/modules/security_hub/main.tf
+++ b/modules/security_hub/main.tf
@@ -2,6 +2,10 @@ resource "aws_securityhub_account" "main" {
   control_finding_generator = var.control_finding_generator
   auto_enable_controls      = var.auto_enable_controls
   enable_default_standards  = var.enable_default_standards
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 data "aws_caller_identity" "current" {

--- a/modules/security_hub/main.tf
+++ b/modules/security_hub/main.tf
@@ -1,4 +1,8 @@
-resource "aws_securityhub_account" "main" {}
+resource "aws_securityhub_account" "main" {
+    control_finding_generator = var.control_finding_generator
+    auto_enable_controls      = var.auto_enable_controls
+    enable_default_standards  = var.enable_default_standards
+}
 
 data "aws_caller_identity" "current" {
 }

--- a/modules/security_hub/main.tf
+++ b/modules/security_hub/main.tf
@@ -1,7 +1,7 @@
 resource "aws_securityhub_account" "main" {
-    control_finding_generator = var.control_finding_generator
-    auto_enable_controls      = var.auto_enable_controls
-    enable_default_standards  = var.enable_default_standards
+  control_finding_generator = var.control_finding_generator
+  auto_enable_controls      = var.auto_enable_controls
+  enable_default_standards  = var.enable_default_standards
 }
 
 data "aws_caller_identity" "current" {

--- a/modules/security_hub/variables.tf
+++ b/modules/security_hub/variables.tf
@@ -83,13 +83,13 @@ variable "control_finding_generator" {
   description = "Updates whether the calling account has consolidated control findings turned on"
 }
 
-# added in v4.64.0 with a default of true, so flip to false
+# added in v4.64.0 with a default of true
 variable "auto_enable_controls" {
   type        = bool
-  default     = false
+  default     = true
   description = "Whether to automatically enable new controls when they are added to standards that are enabled"
 }
-# added in v4.60.0 with default of true, so flip
+# added in v4.60.0 with default of true, but we'll set to false
 variable "enable_default_standards" {
   type        = bool
   default     = false

--- a/modules/security_hub/variables.tf
+++ b/modules/security_hub/variables.tf
@@ -72,3 +72,26 @@ variable "sns_success_feedback_role_arn" {
   type        = string
   description = "The ARN of the IAM role that allows Amazon SNS to write logs about SMS deliveries in CloudWatch Logs."
 }
+
+
+### security hub >= v4.60 additions
+
+# added in v4.64.0 with a default of 'SECURITY_CONTROL' which breaks current config
+variable "control_finding_generator" {
+  type        = string
+  default     = "STANDARD_CONTROL"
+  description = "Updates whether the calling account has consolidated control findings turned on"
+}
+
+# added in v4.64.0 with a default of true, so flip to false
+variable "auto_enable_controls" {
+  type        = bool
+  default     = false
+  description = "Whether to automatically enable new controls when they are added to standards that are enabled"
+}
+# added in v4.60.0 with default of true, so flip
+variable "enable_default_standards" {
+  type        = bool
+  default     = false
+  description = "Whether to enable the security standards that Security Hub has designated as automatically enabled"
+}

--- a/security_hub.tf
+++ b/security_hub.tf
@@ -17,4 +17,8 @@ module "security_hub" {
   fsbp_standard_control_elb_6_enabled       = var.fsbp_standard_control_elb_6_enabled
   sns_failure_feedback_role_arn             = aws_iam_role.sns_failure_feedback.arn
   sns_success_feedback_role_arn             = aws_iam_role.sns_success_feedback.arn
+
+  control_finding_generator = var.control_finding_generator
+  auto_enable_controls      = var.auto_enable_controls
+  enable_default_standards  = var.enable_default_standards
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0"
+      version = "~> 4.0"
       configuration_aliases = [
         aws.eu-west-2,
         aws.global,

--- a/variables.tf
+++ b/variables.tf
@@ -256,13 +256,13 @@ variable "control_finding_generator" {
   description = "Updates whether the calling account has consolidated control findings turned on"
 }
 
-# added in v4.64.0 with a default of true, so flip to false 
+# added in v4.64.0 with a default of true
 variable "auto_enable_controls" {
   type        = bool
-  default     = false
+  default     = true
   description = "Whether to automatically enable new controls when they are added to standards that are enabled"
 }
-# added in v4.60.0 with default of true, so flip
+# added in v4.60.0 with default of true, but we'll set to false
 variable "enable_default_standards" {
   type        = bool
   default     = false

--- a/variables.tf
+++ b/variables.tf
@@ -247,6 +247,28 @@ variable "custom_alarms_breakglass_login_alarm_enabled" {
   type        = bool
 }
 
+### security hub >= v4.60 additions
+
+# added in v4.64.0 with a default of 'SECURITY_CONTROL' which breaks current config
+variable "control_finding_generator" {
+  type        = string
+  default     = "STANDARD_CONTROL"
+  description = "Updates whether the calling account has consolidated control findings turned on"
+}
+
+# added in v4.64.0 with a default of true, so flip to false 
+variable "auto_enable_controls" {
+  type        = bool
+  default     = false
+  description = "Whether to automatically enable new controls when they are added to standards that are enabled"
+}
+# added in v4.60.0 with default of true, so flip
+variable "enable_default_standards" {
+  type        = bool
+  default     = false
+  description = "Whether to enable the security standards that Security Hub has designated as automatically enabled"
+}
+
 locals {
   aws_cost_anomaly_notifications_enabled = var.aws_slack_notifications_enabled && var.aws_slack_cost_anomaly_notification_channel != "" ? true : false
   aws_health_notifications_enabled       = var.aws_slack_notifications_enabled && var.aws_slack_health_notification_channel != "" ? true : false


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_account#argument-reference

Three new params have been added with defaults that clash with our config and how accounts are setup, so add in vars for these params and swap them to values that dont fail.

Added `lifecycle` policy so any destroy attempts will fail on the plan