### PR TITLE
bucket ownership policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Enables Guardduty
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.67 |
 
 ## Providers
 

--- a/modules/cloudtrail/s3.tf
+++ b/modules/cloudtrail/s3.tf
@@ -1,5 +1,4 @@
 resource "aws_s3_bucket" "cloudtrail" {
-  acl    = "log-delivery-write"
   bucket = var.bucket_name
   logging {
     target_bucket = var.s3_access_logging_bucket_name
@@ -29,6 +28,22 @@ resource "aws_s3_bucket" "cloudtrail" {
     }
   }
 }
+
+# See AWS bucket change - https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/
+resource "aws_s3_bucket_ownership_controls" "cloudtrail" {
+  bucket = aws_s3_bucket.cloudtrail.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "cloudtrail" {
+  depends_on = [aws_s3_bucket_ownership_controls.cloudtrail]
+  bucket     = aws_s3_bucket.cloudtrail.id
+  acl        = "log-delivery-write"
+}
+
 
 
 resource "aws_s3_bucket_public_access_block" "cloudtrail" {

--- a/modules/region/s3_access_logging.tf
+++ b/modules/region/s3_access_logging.tf
@@ -1,6 +1,6 @@
 resource "aws_s3_bucket" "s3_access_logging" {
   bucket = "s3-access-logs-opg-${var.product}-${var.account_name}-${data.aws_region.current.name}"
-  acl    = "log-delivery-write"
+
   versioning {
     enabled = true
   }
@@ -36,6 +36,14 @@ resource "aws_s3_bucket_ownership_controls" "s3_access_logging" {
     object_ownership = "BucketOwnerPreferred"
   }
 }
+
+resource "aws_s3_bucket_acl" "s3_access_logging" {
+  depends_on = [aws_s3_bucket_ownership_controls.s3_access_logging]
+  bucket     = aws_s3_bucket.s3_access_logging.id
+  acl        = "log-delivery-write"
+}
+
+
 
 resource "aws_s3_bucket_public_access_block" "s3_access_logging" {
   bucket                  = aws_s3_bucket.s3_access_logging.id

--- a/modules/region/s3_access_logging.tf
+++ b/modules/region/s3_access_logging.tf
@@ -28,6 +28,15 @@ resource "aws_s3_bucket" "s3_access_logging" {
   }
 }
 
+# See AWS bucket change - https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/
+resource "aws_s3_bucket_ownership_controls" "s3_access_logging" {
+  bucket = aaws_s3_bucket.s3_access_logging.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_public_access_block" "s3_access_logging" {
   bucket                  = aws_s3_bucket.s3_access_logging.id
   block_public_acls       = true

--- a/modules/region/s3_access_logging.tf
+++ b/modules/region/s3_access_logging.tf
@@ -30,7 +30,7 @@ resource "aws_s3_bucket" "s3_access_logging" {
 
 # See AWS bucket change - https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/
 resource "aws_s3_bucket_ownership_controls" "s3_access_logging" {
-  bucket = aaws_s3_bucket.s3_access_logging.id
+  bucket = aws_s3_bucket.s3_access_logging.id
 
   rule {
     object_ownership = "BucketOwnerPreferred"

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 4.67"
       configuration_aliases = [
         aws.eu-west-2,
         aws.global,


### PR DESCRIPTION
AWS changed some defaults on [bucket creation in april](https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/) which meant creating new buckets for cloudtrail / access logging failed if they didnt exist already.

This PR moves the `ownership_control` and  `acl` setup to own resource blocks so they are created correctly.

*Note:* There does seem to be a time delay on that, so first `apply` might fail due to that