### PR TITLE
UML-3211 Add an association for DRT access role #major

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Enables Guardduty
 | [aws_s3_account_public_access_block.block_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_account_public_access_block) | resource |
 | [aws_secretsmanager_secret.aws_notifier_slack_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.aws_notifier_slack_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_shield_drt_access_role_arn_association.aws_srt_support_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_drt_access_role_arn_association) | resource |
 | [aws_cloudwatch_log_group.cloudtrail_log_group_vendored](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) | data source |
 | [aws_ecr_repository.cost_notifier_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecr_repository) | data source |
 | [aws_ecr_repository.health_notifier_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecr_repository) | data source |
@@ -133,6 +134,7 @@ Enables Guardduty
 | <a name="input_operator_create_instance_profile"></a> [operator\_create\_instance\_profile](#input\_operator\_create\_instance\_profile) | n/a | `bool` | `false` | no |
 | <a name="input_operator_custom_policy_json"></a> [operator\_custom\_policy\_json](#input\_operator\_custom\_policy\_json) | n/a | `string` | `""` | no |
 | <a name="input_product"></a> [product](#input\_product) | n/a | `string` | n/a | yes |
+| <a name="input_shield_support_role_enabled"></a> [shield\_support\_role\_enabled](#input\_shield\_support\_role\_enabled) | Whether to create the Shield Support Role to allow AWS security engineers to access the account to assist with DDoS mitigation | `bool` | `false` | no |
 | <a name="input_team_email"></a> [team\_email](#input\_team\_email) | Team group email address for use in tags | `string` | `"opgteam@digital.justice.gov.uk"` | no |
 | <a name="input_team_name"></a> [team\_name](#input\_team\_name) | Name of the Team looking after the Service | `string` | `"OPG"` | no |
 | <a name="input_user_arns"></a> [user\_arns](#input\_user\_arns) | n/a | <pre>object({<br>    view       = list(string)<br>    operation  = list(string)<br>    breakglass = list(string)<br>    ci         = list(string)<br>    billing    = list(string)<br>  })</pre> | n/a | yes |

--- a/shield_advanced.tf
+++ b/shield_advanced.tf
@@ -37,3 +37,8 @@ resource "aws_iam_role_policy_attachment" "aws_srt_support_managed_policy" {
   role       = aws_iam_role.aws_srt_support[0].name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSShieldDRTAccessPolicy"
 }
+
+resource "aws_shield_drt_access_role_arn_association" "aws_srt_support_association" {
+  count    = local.shield_support_role_enabled ? 1 : 0
+  role_arn = aws_iam_role.aws_srt_support[0].arn
+}

--- a/variables.tf
+++ b/variables.tf
@@ -281,14 +281,20 @@ variable "modernisation_platform_account" {
   description = "IF this is a vendored account from the Modernisation Platform"
 }
 
+variable "shield_support_role_enabled" {
+  type        = bool
+  default     = false
+  description = "Whether to create the Shield Support Role to allow AWS security engineers to access the account to assist with DDoS mitigation"
+}
+
 locals {
   aws_cost_anomaly_notifications_enabled = var.aws_slack_notifications_enabled && var.aws_slack_cost_anomaly_notification_channel != "" ? true : false
   aws_health_notifications_enabled       = var.aws_slack_notifications_enabled && var.aws_slack_health_notification_channel != "" ? true : false
 
-  # Locals to control provisioning of Moernisation Platform Provisioned Services in new accounts.
+  # Locals to control provisioning of Modernisation Platform Provisioned Services in new accounts.
   cloudtrail_enabled          = !var.modernisation_platform_account
   config_enabled              = var.aws_config_enabled && !var.modernisation_platform_account ? true : false
   guardduty_enabled           = var.enable_guardduty && !var.modernisation_platform_account ? true : false
   security_hub_enabled        = var.aws_security_hub_enabled && !var.modernisation_platform_account ? true : false
-  shield_support_role_enabled = !var.modernisation_platform_account
+  shield_support_role_enabled = var.shield_support_role_enabled && !var.modernisation_platform_account ? true : false
 }


### PR DESCRIPTION
Add a `aws_shield_drt_access_role_arn_association` resource for the aws_srt_support IAM role to allow AWS SRT to access accounts where the `shield_support_role_enabled` variable is set to true and the `modernisation_platform_account` is set to false.

Previously, the IAM role would be created when the `modernisation_platform_account` variable was set to false.

AWS Accounts where the association has been manually created will need to set `shield_support_role_enabled` to true.