### PR TITLE
Add support for OAM links

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Enables Guardduty
 | <a name="input_fsbp_standard_control_elb_6_enabled"></a> [fsbp\_standard\_control\_elb\_6\_enabled](#input\_fsbp\_standard\_control\_elb\_6\_enabled) | When false, sets standard control to disabled. | `bool` | `true` | no |
 | <a name="input_is_production"></a> [is\_production](#input\_is\_production) | n/a | `bool` | `false` | no |
 | <a name="input_modernisation_platform_account"></a> [modernisation\_platform\_account](#input\_modernisation\_platform\_account) | IF this is a vendored account from the Modernisation Platform | `bool` | `false` | no |
+| <a name="input_oam_xray_sink_identifier_arn"></a> [oam\_xray\_sink\_identifier\_arn](#input\_oam\_xray\_sink\_identifier\_arn) | The identifier of the OAM Sink to duplicate XRay events to (if desired) | `string` | `null` | no |
 | <a name="input_operator_base_policy_arn"></a> [operator\_base\_policy\_arn](#input\_operator\_base\_policy\_arn) | n/a | `string` | `"arn:aws:iam::aws:policy/ReadOnlyAccess"` | no |
 | <a name="input_operator_create_instance_profile"></a> [operator\_create\_instance\_profile](#input\_operator\_create\_instance\_profile) | n/a | `bool` | `false` | no |
 | <a name="input_operator_custom_policy_json"></a> [operator\_custom\_policy\_json](#input\_operator\_custom\_policy\_json) | n/a | `string` | `""` | no |

--- a/oam.tf
+++ b/oam.tf
@@ -1,0 +1,6 @@
+resource "aws_oam_link" "main" {
+  count           = var.oam_xray_sink_identifier_arn == null ? 0 : 1
+  label_template  = "$AccountName"
+  resource_types  = ["AWS::XRay::Trace"]
+  sink_identifier = var.oam_xray_sink_identifier_arn
+}

--- a/variables.tf
+++ b/variables.tf
@@ -287,6 +287,11 @@ variable "shield_support_role_enabled" {
   description = "Whether to create the Shield Support Role to allow AWS security engineers to access the account to assist with DDoS mitigation"
 }
 
+variable "oam_xray_sink_identifier_arn" {
+  type        = string
+  description = "The identifier of the OAM Sink to duplicate XRay events to (if desired)"
+}
+
 locals {
   aws_cost_anomaly_notifications_enabled = var.aws_slack_notifications_enabled && var.aws_slack_cost_anomaly_notification_channel != "" ? true : false
   aws_health_notifications_enabled       = var.aws_slack_notifications_enabled && var.aws_slack_health_notification_channel != "" ? true : false


### PR DESCRIPTION
If an `oam_xray_sink_identifier_arn` is provided, create a link with that sink for sending XRay traces

#minor