### PR TITLE
Make `oam_xray_sink_identifier_arn` optional

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -289,6 +289,7 @@ variable "shield_support_role_enabled" {
 
 variable "oam_xray_sink_identifier_arn" {
   type        = string
+  default     = null
   description = "The identifier of the OAM Sink to duplicate XRay events to (if desired)"
 }
 


### PR DESCRIPTION
By adding a devault value (even if it's null), Terraform no longer considers the variable required

#patch