### PR TITLE
SP-1923 - AWS Configuration Scanning #minor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,3 @@
-# opg-terraform-aws-account
-Managed by opg-org-infra &amp; Terraform
-
-Provides standard default configuration for AWS accounts.
-
-Creates default assumable roles for viewers, operators and breakglass access.
-Creates cloudtrails in each account.
-Sets up a strong password policy for IAM users.
-Enables Guardduty
-
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 | Name | Version |
@@ -110,6 +99,7 @@ Enables Guardduty
 | <a name="input_cis_metric_namespace"></a> [cis\_metric\_namespace](#input\_cis\_metric\_namespace) | The destination namespace of the CIS CloudWatch metric. | `string` | `"CISLogMetrics"` | no |
 | <a name="input_cloudtrail_bucket_name"></a> [cloudtrail\_bucket\_name](#input\_cloudtrail\_bucket\_name) | trail name | `string` | `"cloudtrail"` | no |
 | <a name="input_cloudtrail_trail_name"></a> [cloudtrail\_trail\_name](#input\_cloudtrail\_trail\_name) | trail name | `string` | `"cloudtrail"` | no |
+| <a name="input_config_continuous_resource_recording"></a> [config\_continuous\_resource\_recording](#input\_config\_continuous\_resource\_recording) | Should the configuration recorder scan constantly or daily (set to false in dev accounts) | `bool` | `true` | no |
 | <a name="input_control_finding_generator"></a> [control\_finding\_generator](#input\_control\_finding\_generator) | Updates whether the calling account has consolidated control findings turned on | `string` | `"STANDARD_CONTROL"` | no |
 | <a name="input_cost_anomaly_immediate_schedule_threshold"></a> [cost\_anomaly\_immediate\_schedule\_threshold](#input\_cost\_anomaly\_immediate\_schedule\_threshold) | The value that triggers an immediate notification if the threshold is exceeded. By default, an absolute dollar value, but changing `threshold_expression_type` changes this to percentage. | `string` | `"10.0"` | no |
 | <a name="input_cost_anomaly_notification_email_address"></a> [cost\_anomaly\_notification\_email\_address](#input\_cost\_anomaly\_notification\_email\_address) | Email address to use to send anomaly alerts to | `string` | `null` | no |
@@ -141,4 +131,3 @@ Enables Guardduty
 | <a name="output_aws_sns_topic_cis_aws_foundations_standard"></a> [aws\_sns\_topic\_cis\_aws\_foundations\_standard](#output\_aws\_sns\_topic\_cis\_aws\_foundations\_standard) | n/a |
 | <a name="output_aws_sns_topic_custom_cloudwatch_alarms"></a> [aws\_sns\_topic\_custom\_cloudwatch\_alarms](#output\_aws\_sns\_topic\_custom\_cloudwatch\_alarms) | n/a |
 | <a name="output_aws_sns_topic_slack_notification_failures"></a> [aws\_sns\_topic\_slack\_notification\_failures](#output\_aws\_sns\_topic\_slack\_notification\_failures) | n/a |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/config/config.tf
+++ b/modules/config/config.tf
@@ -6,6 +6,9 @@ resource "aws_config_configuration_recorder" "main" {
     all_supported                 = true
     include_global_resource_types = true
   }
+  recording_mode {
+    recording_frequency = var.config_continuous_resource_recording ? "CONTINUOUS" : "DAILY"
+  }
 }
 
 resource "aws_config_configuration_recorder_status" "main" {

--- a/modules/config/variables.tf
+++ b/modules/config/variables.tf
@@ -20,6 +20,12 @@ variable "config_max_execution_frequency" {
   default     = "TwentyFour_Hours"
 }
 
+variable "config_continuous_resource_recording" {
+  description = "Should the configuration recorder scan constantly or daily (set to false in dev accounts)"
+  type        = bool
+  default     = true
+}
+
 variable "product" {
   default     = ""
   description = "Product/Service name"

--- a/modules/region/config.tf
+++ b/modules/region/config.tf
@@ -1,10 +1,12 @@
 module "aws_config" {
-  source                        = "../config"
-  count                         = var.aws_config_enabled ? 1 : 0
-  account_name                  = var.account_name
-  config_iam_role               = var.config_iam_role
-  s3_access_logging_bucket_name = aws_s3_bucket.s3_access_logging.id
-  product                       = var.product
-  sns_failure_feedback_role_arn = var.sns_failure_feedback_role_arn
-  sns_success_feedback_role_arn = var.sns_success_feedback_role_arn
+  source                               = "../config"
+  count                                = var.aws_config_enabled ? 1 : 0
+  account_name                         = var.account_name
+  config_iam_role                      = var.config_iam_role
+  config_continuous_resource_recording = var.config_continuous_resource_recording
+  s3_access_logging_bucket_name        = aws_s3_bucket.s3_access_logging.id
+  product                              = var.product
+  sns_failure_feedback_role_arn        = var.sns_failure_feedback_role_arn
+  sns_success_feedback_role_arn        = var.sns_success_feedback_role_arn
 }
+

--- a/modules/region/variables.tf
+++ b/modules/region/variables.tf
@@ -13,6 +13,13 @@ variable "config_iam_role" {
   description = "Iam role object for the config role."
 }
 
+variable "config_continuous_resource_recording" {
+  description = "Should the configuration recorder scan constantly or daily (set to false in dev accounts)"
+  type        = bool
+  default     = true
+}
+
+
 variable "product" {
   description = "Name of the product"
   type        = string

--- a/regions.tf
+++ b/regions.tf
@@ -1,24 +1,26 @@
 module "eu-west-1" {
-  source                        = "./modules/region"
-  account_name                  = var.account_name
-  aws_config_enabled            = local.config_enabled
-  config_iam_role               = local.config_enabled ? aws_iam_role.config[0] : null
-  product                       = var.product
-  sns_failure_feedback_role_arn = aws_iam_role.sns_failure_feedback.arn
-  sns_success_feedback_role_arn = aws_iam_role.sns_success_feedback.arn
+  source                               = "./modules/region"
+  account_name                         = var.account_name
+  aws_config_enabled                   = local.config_enabled
+  config_iam_role                      = local.config_enabled ? aws_iam_role.config[0] : null
+  config_continuous_resource_recording = var.config_continuous_resource_recording
+  product                              = var.product
+  sns_failure_feedback_role_arn        = aws_iam_role.sns_failure_feedback.arn
+  sns_success_feedback_role_arn        = aws_iam_role.sns_success_feedback.arn
   providers = {
     aws = aws
   }
 }
 
 module "eu-west-2" {
-  source                        = "./modules/region"
-  account_name                  = var.account_name
-  aws_config_enabled            = local.config_enabled
-  config_iam_role               = local.config_enabled ? aws_iam_role.config[0] : null
-  product                       = var.product
-  sns_failure_feedback_role_arn = aws_iam_role.sns_failure_feedback.arn
-  sns_success_feedback_role_arn = aws_iam_role.sns_success_feedback.arn
+  source                               = "./modules/region"
+  account_name                         = var.account_name
+  aws_config_enabled                   = local.config_enabled
+  config_iam_role                      = local.config_enabled ? aws_iam_role.config[0] : null
+  config_continuous_resource_recording = var.config_continuous_resource_recording
+  product                              = var.product
+  sns_failure_feedback_role_arn        = aws_iam_role.sns_failure_feedback.arn
+  sns_success_feedback_role_arn        = aws_iam_role.sns_success_feedback.arn
   providers = {
     aws = aws.eu-west-2
   }

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,12 @@ variable "aws_config_enabled" {
   default = false
 }
 
+variable "config_continuous_resource_recording" {
+  description = "Should the configuration recorder scan constantly or daily (set to false in dev accounts)"
+  type        = bool
+  default     = true
+}
+
 variable "aws_security_hub_enabled" {
   type    = bool
   default = false


### PR DESCRIPTION
Allow to configure AWS Config with DAILY rather than CONTINOUS scanning to reduce config recorder costs in high cadence accounts #minor