### PR TITLE
MLPAB-2009 - manage account alias in module

### DIFF
--- a/account.tf
+++ b/account.tf
@@ -1,0 +1,4 @@
+resource "aws_iam_account_alias" "main" {
+  account_alias = var.aws_iam_account_alias
+  provider      = aws.global
+}

--- a/variables.tf
+++ b/variables.tf
@@ -310,3 +310,16 @@ locals {
   security_hub_enabled        = var.aws_security_hub_enabled && !var.modernisation_platform_account ? true : false
   shield_support_role_enabled = var.shield_support_role_enabled && !var.modernisation_platform_account ? true : false
 }
+
+variable "aws_iam_account_alias" {
+  description = "The AWS IAM Account Alias to use for the account"
+  type        = string
+  validation {
+    condition     = length(var.aws_iam_account_alias) > 0
+    error_message = "The AWS IAM Account Alias must be set."
+  }
+  validation {
+    condition     = can(regexall("^[a-zA-Z0-9-]+$", var.aws_iam_account_alias))
+    error_message = "The AWS IAM Account Alias must only contain alphanumeric characters and hyphens."
+  }
+}


### PR DESCRIPTION
MLPAB-2009 - Manage account alias

https://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html#CreateAccountAlias

Adds `aws_iam_account_alias` to the module.

If you already have an alias that isn't managed you can import this resource

```hcl
import {
    to = module.account_module_name.aws_iam_account_alias.main
    id = "my-account-alias"
}

```

If you are already managing an alias in org-infra, you can move it

https://developer.hashicorp.com/terraform/language/modules/develop/refactoring
