### PR TITLE
Swap base role back and add deny

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 | [aws_iam_account_alias.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_alias) | resource |
 | [aws_iam_account_password_policy.strict](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy) | resource |
 | [aws_iam_policy.aws_cost_explorer_access_for_billing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.cloudwatch_reporting](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.aws_srt_support](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.sns_failure_feedback](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -128,7 +129,7 @@
 | <a name="input_shield_support_role_enabled"></a> [shield\_support\_role\_enabled](#input\_shield\_support\_role\_enabled) | Whether to create the Shield Support Role to allow AWS security engineers to access the account to assist with DDoS mitigation | `bool` | `false` | no |
 | <a name="input_team_email"></a> [team\_email](#input\_team\_email) | Team group email address for use in tags | `string` | `"opgteam@digital.justice.gov.uk"` | no |
 | <a name="input_team_name"></a> [team\_name](#input\_team\_name) | Name of the Team looking after the Service | `string` | `"OPG"` | no |
-| <a name="input_user_arns"></a> [user\_arns](#input\_user\_arns) | n/a | <pre>object({<br>    view                = list(string)<br>    operation           = list(string)<br>    breakglass          = list(string)<br>    ci                  = list(string)<br>    billing             = list(string)<br>    cloudwatch_reporting = list(string)<br>  })</pre> | n/a | yes |
+| <a name="input_user_arns"></a> [user\_arns](#input\_user\_arns) | n/a | <pre>object({<br>    view                 = list(string)<br>    operation            = list(string)<br>    breakglass           = list(string)<br>    ci                   = list(string)<br>    billing              = list(string)<br>    cloudwatch_reporting = list(string)<br>  })</pre> | n/a | yes |
 | <a name="input_viewer_base_policy_arn"></a> [viewer\_base\_policy\_arn](#input\_viewer\_base\_policy\_arn) | n/a | `string` | `"arn:aws:iam::aws:policy/ReadOnlyAccess"` | no |
 | <a name="input_viewer_custom_policy_json"></a> [viewer\_custom\_policy\_json](#input\_viewer\_custom\_policy\_json) | n/a | `string` | `""` | no |
 

--- a/roles.tf
+++ b/roles.tf
@@ -97,5 +97,5 @@ module "cloudwatch_reporting" {
   source          = "./modules/default_roles"
   name            = "cloudwatch-reporting-ci"
   user_arns       = var.user_arns.cloudwatch_reporting
-  base_policy_arn = aws_iam_policy.cloudwatch_reporting
+  base_policy_arn = aws_iam_policy.cloudwatch_reporting.arn
 }

--- a/roles.tf
+++ b/roles.tf
@@ -75,6 +75,21 @@ module "ci" {
 
 data "aws_iam_policy_document" "cloudwatch_reporting_policy" {
   statement {
+    sid    = "DenyOthers"
+    effect = "Deny"
+    actions = [
+      "application-autoscaling:*",
+      "autoscaling:*",
+      "logs:*",
+      "oam:*",
+      "sns:*",
+      "rum:*",
+      "synthetics:*",
+      "xray:*",
+    ]
+    resources = ["*"]
+  }
+  statement {
     sid    = "AllowCloudWatchReports"
     effect = "Allow"
     actions = [
@@ -91,6 +106,6 @@ module "cloudwatch_reporting" {
   source             = "./modules/default_roles"
   name               = "cloudwatch-reporting-ci"
   user_arns          = var.user_arns.cloudwatch_reporting
-  base_policy_arn    = "arn:aws:iam::aws:policy/AWSDenyAll"
+  base_policy_arn    = "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
   custom_policy_json = data.aws_iam_policy_document.cloudwatch_reporting_policy.json
 }

--- a/roles.tf
+++ b/roles.tf
@@ -75,21 +75,6 @@ module "ci" {
 
 data "aws_iam_policy_document" "cloudwatch_reporting_policy" {
   statement {
-    sid    = "DenyOthers"
-    effect = "Deny"
-    actions = [
-      "application-autoscaling:*",
-      "autoscaling:*",
-      "logs:*",
-      "oam:*",
-      "sns:*",
-      "rum:*",
-      "synthetics:*",
-      "xray:*",
-    ]
-    resources = ["*"]
-  }
-  statement {
     sid    = "AllowCloudWatchReports"
     effect = "Allow"
     actions = [
@@ -101,11 +86,16 @@ data "aws_iam_policy_document" "cloudwatch_reporting_policy" {
   }
 }
 
+resource "aws_iam_policy" "cloudwatch_reporting" {
+  name        = "cloudwatch_metrics_policy"
+  description = "Policy to allow access to only metric information from cloudwatch"
+  policy      = data.aws_iam_policy_document.cloudwatch_reporting_policy.json
+}
+
 module "cloudwatch_reporting" {
-  count              = local.cloudwatch_reporting_role_enabled == true ? 1 : 0
-  source             = "./modules/default_roles"
-  name               = "cloudwatch-reporting-ci"
-  user_arns          = var.user_arns.cloudwatch_reporting
-  base_policy_arn    = "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
-  custom_policy_json = data.aws_iam_policy_document.cloudwatch_reporting_policy.json
+  count           = local.cloudwatch_reporting_role_enabled == true ? 1 : 0
+  source          = "./modules/default_roles"
+  name            = "cloudwatch-reporting-ci"
+  user_arns       = var.user_arns.cloudwatch_reporting
+  base_policy_arn = aws_iam_policy.cloudwatch_reporting
 }


### PR DESCRIPTION
Deny all as a base blocks all other calls, so swap to the cloudwatch role and instead deny access to the other permissions that role grants to maintain small footprint