### PR TITLE
OIDC roles

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: "Generate semver tag and release"
         id: semver_tag
-        uses: ministryofjustice/opg-github-actions/.github/actions/semver-tag@v2.3.1
+        uses: ministryofjustice/opg-github-actions/.github/actions/semver-tag@v3.0.6
         with:
           prerelease: ${{ github.ref != 'refs/heads/main' }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@
 | <a name="input_enable_guardduty"></a> [enable\_guardduty](#input\_enable\_guardduty) | n/a | `bool` | `true` | no |
 | <a name="input_fsbp_standard_control_elb_6_enabled"></a> [fsbp\_standard\_control\_elb\_6\_enabled](#input\_fsbp\_standard\_control\_elb\_6\_enabled) | When false, sets standard control to disabled. | `bool` | `true` | no |
 | <a name="input_github_oidc_enabled"></a> [github\_oidc\_enabled](#input\_github\_oidc\_enabled) | Enable an oidc provider in the account for use within github actions. Will create a stored query for the access log. | `bool` | `false` | no |
-| <a name="input_github_oidc_permissions"></a> [github\_oidc\_permissions](#input\_github\_oidc\_permissions) | Permissions to scope the oidc role to | `list(string)` | <pre>[<br>  "repo:ministryofjustice/opg-reports:pull_request",<br>  "repo:ministryofjustice/opg-reports:ref:refs/heads/*"<br>]</pre> | no |
 | <a name="input_is_production"></a> [is\_production](#input\_is\_production) | n/a | `bool` | `false` | no |
 | <a name="input_modernisation_platform_account"></a> [modernisation\_platform\_account](#input\_modernisation\_platform\_account) | IF this is a vendored account from the Modernisation Platform | `bool` | `false` | no |
 | <a name="input_oam_xray_sink_identifier_arn"></a> [oam\_xray\_sink\_identifier\_arn](#input\_oam\_xray\_sink\_identifier\_arn) | The identifier of the OAM Sink to duplicate XRay events to (if desired) | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -17,19 +17,19 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_billing"></a> [billing](#module\_billing) | ./modules/default_roles | n/a |
 | <a name="module_breakglass"></a> [breakglass](#module\_breakglass) | ./modules/default_roles | n/a |
 | <a name="module_ci"></a> [ci](#module\_ci) | ./modules/default_roles | n/a |
 | <a name="module_cloudtrail"></a> [cloudtrail](#module\_cloudtrail) | ./modules/cloudtrail | n/a |
 | <a name="module_cloudwatch_loginsights_cis_queries_opg"></a> [cloudwatch\_loginsights\_cis\_queries\_opg](#module\_cloudwatch\_loginsights\_cis\_queries\_opg) | ./modules/cis_queries | n/a |
 | <a name="module_cloudwatch_loginsights_cis_queries_provisioned"></a> [cloudwatch\_loginsights\_cis\_queries\_provisioned](#module\_cloudwatch\_loginsights\_cis\_queries\_provisioned) | ./modules/cis_queries | n/a |
-| <a name="module_cloudwatch_reporting"></a> [cloudwatch\_reporting](#module\_cloudwatch\_reporting) | ./modules/default_roles | n/a |
 | <a name="module_cost_anomaly_detection"></a> [cost\_anomaly\_detection](#module\_cost\_anomaly\_detection) | ./modules/ce_anomaly_detection | n/a |
 | <a name="module_custom_cloudwatch_alarms"></a> [custom\_cloudwatch\_alarms](#module\_custom\_cloudwatch\_alarms) | ./modules/custom_cloudwatch_alarms | n/a |
 | <a name="module_custom_cloudwatch_alarms_vendored"></a> [custom\_cloudwatch\_alarms\_vendored](#module\_custom\_cloudwatch\_alarms\_vendored) | ./modules/custom_cloudwatch_alarms | n/a |
 | <a name="module_eu-west-1"></a> [eu-west-1](#module\_eu-west-1) | ./modules/region | n/a |
 | <a name="module_eu-west-2"></a> [eu-west-2](#module\_eu-west-2) | ./modules/region | n/a |
 | <a name="module_github_oidc_provider"></a> [github\_oidc\_provider](#module\_github\_oidc\_provider) | ./modules/github_oidc_provider | n/a |
+| <a name="module_github_oidc_role_cost_data"></a> [github\_oidc\_role\_cost\_data](#module\_github\_oidc\_role\_cost\_data) | ./modules/github_oidc_roles | n/a |
+| <a name="module_github_oidc_role_uptime_data"></a> [github\_oidc\_role\_uptime\_data](#module\_github\_oidc\_role\_uptime\_data) | ./modules/github_oidc_roles | n/a |
 | <a name="module_operator"></a> [operator](#module\_operator) | ./modules/default_roles | n/a |
 | <a name="module_security_hub"></a> [security\_hub](#module\_security\_hub) | ./modules/security_hub | n/a |
 | <a name="module_slack_notifications"></a> [slack\_notifications](#module\_slack\_notifications) | ./modules/slack_notifications | n/a |
@@ -46,8 +46,6 @@
 | [aws_guardduty_detector.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_detector) | resource |
 | [aws_iam_account_alias.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_alias) | resource |
 | [aws_iam_account_password_policy.strict](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy) | resource |
-| [aws_iam_policy.aws_cost_explorer_access_for_billing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.cloudwatch_reporting](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.aws_srt_support](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.sns_failure_feedback](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -55,7 +53,6 @@
 | [aws_iam_role_policy.sns_failure_feedback](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.sns_success_feedback](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.aws_billing_access_for_operator](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.aws_cost_explorer_access_for_billing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.aws_srt_support_managed_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.aws_support_access_for_breakglass](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.managed_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -64,11 +61,11 @@
 | [aws_shield_drt_access_role_arn_association.aws_srt_support_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_drt_access_role_arn_association) | resource |
 | [aws_cloudwatch_log_group.cloudtrail_log_group_vendored](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) | data source |
 | [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.aws_cost_explorer_access_for_billing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.aws_srt_support_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.cloudwatch_reporting_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cost_metrics](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.sns_feedback_actions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.sns_feedback_assume_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.uptime_metrics](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
@@ -90,8 +87,6 @@
 | <a name="input_aws_slack_cost_anomaly_notification_channel"></a> [aws\_slack\_cost\_anomaly\_notification\_channel](#input\_aws\_slack\_cost\_anomaly\_notification\_channel) | Slack's internal ID for the channel you want to post cost anomalies to. Format AB1C2DEF | `string` | `""` | no |
 | <a name="input_aws_slack_health_notification_channel"></a> [aws\_slack\_health\_notification\_channel](#input\_aws\_slack\_health\_notification\_channel) | Slack's internal ID for the channel you want to post health alrets to. Format AB1C2DEF | `string` | `""` | no |
 | <a name="input_aws_slack_notifications_enabled"></a> [aws\_slack\_notifications\_enabled](#input\_aws\_slack\_notifications\_enabled) | Whether to enable alerting to slack. To be used with slack cost/health notification channel. | `bool` | `false` | no |
-| <a name="input_billing_base_policy_arn"></a> [billing\_base\_policy\_arn](#input\_billing\_base\_policy\_arn) | n/a | `string` | `"arn:aws:iam::aws:policy/job-function/Billing"` | no |
-| <a name="input_billing_custom_policy_json"></a> [billing\_custom\_policy\_json](#input\_billing\_custom\_policy\_json) | n/a | `string` | `""` | no |
 | <a name="input_breakglass_base_policy_arn"></a> [breakglass\_base\_policy\_arn](#input\_breakglass\_base\_policy\_arn) | n/a | `string` | `"arn:aws:iam::aws:policy/AdministratorAccess"` | no |
 | <a name="input_breakglass_create_instance_profile"></a> [breakglass\_create\_instance\_profile](#input\_breakglass\_create\_instance\_profile) | n/a | `bool` | `false` | no |
 | <a name="input_breakglass_custom_policy_json"></a> [breakglass\_custom\_policy\_json](#input\_breakglass\_custom\_policy\_json) | n/a | `string` | `""` | no |
@@ -121,6 +116,7 @@
 | <a name="input_enable_guardduty"></a> [enable\_guardduty](#input\_enable\_guardduty) | n/a | `bool` | `true` | no |
 | <a name="input_fsbp_standard_control_elb_6_enabled"></a> [fsbp\_standard\_control\_elb\_6\_enabled](#input\_fsbp\_standard\_control\_elb\_6\_enabled) | When false, sets standard control to disabled. | `bool` | `true` | no |
 | <a name="input_github_oidc_enabled"></a> [github\_oidc\_enabled](#input\_github\_oidc\_enabled) | Enable an oidc provider in the account for use within github actions. Will create a stored query for the access log. | `bool` | `false` | no |
+| <a name="input_github_oidc_permissions"></a> [github\_oidc\_permissions](#input\_github\_oidc\_permissions) | Permissions to scope the oidc role to | `list(string)` | <pre>[<br>  "repo:ministryofjustice/opg-reports:pull_request",<br>  "repo:ministryofjustice/opg-reports:ref:refs/heads/*"<br>]</pre> | no |
 | <a name="input_is_production"></a> [is\_production](#input\_is\_production) | n/a | `bool` | `false` | no |
 | <a name="input_modernisation_platform_account"></a> [modernisation\_platform\_account](#input\_modernisation\_platform\_account) | IF this is a vendored account from the Modernisation Platform | `bool` | `false` | no |
 | <a name="input_oam_xray_sink_identifier_arn"></a> [oam\_xray\_sink\_identifier\_arn](#input\_oam\_xray\_sink\_identifier\_arn) | The identifier of the OAM Sink to duplicate XRay events to (if desired) | `string` | `null` | no |
@@ -132,7 +128,7 @@
 | <a name="input_shield_support_role_enabled"></a> [shield\_support\_role\_enabled](#input\_shield\_support\_role\_enabled) | Whether to create the Shield Support Role to allow AWS security engineers to access the account to assist with DDoS mitigation | `bool` | `false` | no |
 | <a name="input_team_email"></a> [team\_email](#input\_team\_email) | Team group email address for use in tags | `string` | `"opgteam@digital.justice.gov.uk"` | no |
 | <a name="input_team_name"></a> [team\_name](#input\_team\_name) | Name of the Team looking after the Service | `string` | `"OPG"` | no |
-| <a name="input_user_arns"></a> [user\_arns](#input\_user\_arns) | n/a | <pre>object({<br>    view                 = list(string)<br>    operation            = list(string)<br>    breakglass           = list(string)<br>    ci                   = list(string)<br>    billing              = list(string)<br>    cloudwatch_reporting = list(string)<br>  })</pre> | n/a | yes |
+| <a name="input_user_arns"></a> [user\_arns](#input\_user\_arns) | n/a | <pre>object({<br>    view       = list(string)<br>    operation  = list(string)<br>    breakglass = list(string)<br>    ci         = list(string)<br>  })</pre> | n/a | yes |
 | <a name="input_viewer_base_policy_arn"></a> [viewer\_base\_policy\_arn](#input\_viewer\_base\_policy\_arn) | n/a | `string` | `"arn:aws:iam::aws:policy/ReadOnlyAccess"` | no |
 | <a name="input_viewer_custom_policy_json"></a> [viewer\_custom\_policy\_json](#input\_viewer\_custom\_policy\_json) | n/a | `string` | `""` | no |
 

--- a/examples/development_account/main.tf
+++ b/examples/development_account/main.tf
@@ -1,8 +1,3 @@
-# Retrieve User ARNs from AWS IAM Groups
-data "aws_iam_group" "billing" {
-  group_name = "billing"
-  provider   = aws.identity
-}
 
 data "aws_iam_group" "breakglass" {
   group_name = "breakglass"
@@ -30,7 +25,6 @@ locals {
     ci         = [aws_iam_user.ci_user.arn]
     operation  = data.aws_iam_group.operators.users[*].arn
     view       = data.aws_iam_group.viewers.users[*].arn
-    billing    = data.aws_iam_group.billing.users[*].arn
   }
 }
 # Description: This module configures an AWS account with some security controls turned off for development purposes.

--- a/examples/full_example/main.tf
+++ b/examples/full_example/main.tf
@@ -20,11 +20,10 @@ data "aws_iam_group" "viewers" {
 
 locals {
   user_arns = {
-    breakglass           = concat(data.aws_iam_group.breakglass.users[*].arn, data.aws_iam_group.breakglass_product.users[*].arn)
-    ci                   = [aws_iam_user.ci_user.arn]
-    cloudwatch_reporting = [aws_iam_user.cloudwatch_ci_user.arn]
-    operation            = data.aws_iam_group.operators.users[*].arn
-    view                 = data.aws_iam_group.viewers.users[*].arn
+    breakglass = concat(data.aws_iam_group.breakglass.users[*].arn, data.aws_iam_group.breakglass_product.users[*].arn)
+    ci         = [aws_iam_user.ci_user.arn]
+    operation  = data.aws_iam_group.operators.users[*].arn
+    view       = data.aws_iam_group.viewers.users[*].arn
 
   }
 }

--- a/examples/full_example/main.tf
+++ b/examples/full_example/main.tf
@@ -1,9 +1,3 @@
-# Retrieve User ARNs from AWS IAM Groups
-data "aws_iam_group" "billing" {
-  group_name = "billing"
-  provider   = aws.identity
-}
-
 data "aws_iam_group" "breakglass" {
   group_name = "breakglass"
   provider   = aws.identity
@@ -31,7 +25,6 @@ locals {
     cloudwatch_reporting = [aws_iam_user.cloudwatch_ci_user.arn]
     operation            = data.aws_iam_group.operators.users[*].arn
     view                 = data.aws_iam_group.viewers.users[*].arn
-    billing              = data.aws_iam_group.billing.users[*].arn
 
   }
 }
@@ -47,8 +40,6 @@ module "full" {
   aws_s3_account_ignore_public_acls            = true
   aws_s3_account_restrict_public_buckets       = true
   aws_security_hub_enabled                     = true
-  billing_base_policy_arn                      = "arn:aws:iam::aws:policy/job-function/Billing"
-  billing_custom_policy_json                   = ""
   breakglass_base_policy_arn                   = "arn:aws:iam::aws:policy/AdministratorAccess"
   breakglass_create_instance_profile           = false
   breakglass_custom_policy_json                = ""

--- a/examples/production_account/main.tf
+++ b/examples/production_account/main.tf
@@ -1,9 +1,3 @@
-# Retrieve User ARNs from AWS IAM Groups
-data "aws_iam_group" "billing" {
-  group_name = "billing"
-  provider   = aws.identity
-}
-
 data "aws_iam_group" "breakglass" {
   group_name = "breakglass"
   provider   = aws.identity
@@ -26,12 +20,10 @@ data "aws_iam_group" "viewers" {
 
 locals {
   user_arns = {
-    breakglass           = concat(data.aws_iam_group.breakglass.users[*].arn, data.aws_iam_group.breakglass_product.users[*].arn)
-    ci                   = [aws_iam_user.ci_user.arn]
-    cloudwatch_reporting = [aws_iam_user.reporting_ci_user.arn]
-    operation            = data.aws_iam_group.operators.users[*].arn
-    view                 = data.aws_iam_group.viewers.users[*].arn
-    billing              = data.aws_iam_group.billing.users[*].arn
+    breakglass = concat(data.aws_iam_group.breakglass.users[*].arn, data.aws_iam_group.breakglass_product.users[*].arn)
+    ci         = [aws_iam_user.ci_user.arn]
+    operation  = data.aws_iam_group.operators.users[*].arn
+    view       = data.aws_iam_group.viewers.users[*].arn
   }
 }
 

--- a/github_oidc_roles.tf
+++ b/github_oidc_roles.tf
@@ -7,7 +7,7 @@ module "github_oidc_role_cost_data" {
   source      = "./modules/github_oidc_roles"
   name        = "gh-actions-cost-metrics"
   description = "Run OPG costs reports"
-  repository  = var.github_oidc_repository
+  permissions = var.github_oidc_permissions
 
   custom_policy_documents = [data.aws_iam_policy_document.cost_metrics.json]
 }
@@ -19,7 +19,7 @@ module "github_oidc_role_uptime_data" {
   source      = "./modules/github_oidc_roles"
   name        = "gh-actions-uptime-metrics"
   description = "Run OPG uptime reports"
-  repository  = var.github_oidc_repository
+  permissions = var.github_oidc_permissions
 
   custom_policy_documents = [data.aws_iam_policy_document.uptime_metrics.json]
 }

--- a/github_oidc_roles.tf
+++ b/github_oidc_roles.tf
@@ -1,6 +1,5 @@
 locals {
-  oidc_assumable_roles = []
-  oidc_permissions = [
+  opg_reports_oidc_permissions = [
     "repo:ministryofjustice/opg-reports:pull_request",
     "repo:ministryofjustice/opg-reports:ref:refs/heads/*"
   ]
@@ -14,8 +13,8 @@ module "github_oidc_role_cost_data" {
   source          = "./modules/github_oidc_roles"
   name            = "gh-actions-cost-metrics"
   description     = "Run OPG costs reports"
-  permissions     = local.oidc_permissions
-  assumable_roles = local.oidc_assumable_roles
+  permissions     = local.opg_reports_oidc_permissions
+  assumable_roles = []
 
   custom_policy_documents = [data.aws_iam_policy_document.cost_metrics.json]
 }
@@ -27,8 +26,8 @@ module "github_oidc_role_uptime_data" {
   source          = "./modules/github_oidc_roles"
   name            = "gh-actions-uptime-metrics"
   description     = "Run OPG uptime reports"
-  permissions     = local.oidc_permissions
-  assumable_roles = local.oidc_assumable_roles
+  permissions     = local.opg_reports_oidc_permissions
+  assumable_roles = []
 
   custom_policy_documents = [data.aws_iam_policy_document.uptime_metrics.json]
 }

--- a/github_oidc_roles.tf
+++ b/github_oidc_roles.tf
@@ -1,0 +1,52 @@
+locals {
+  github_oidc_production_policy = [
+    data.aws_iam_policy_document.uptime_metrics.json,
+    data.aws_iam_policy_document.cost_data.json
+  ]
+  github_oidc_non_production_policy = [
+    data.aws_iam_policy_document.cost_data.json
+  ]
+  github_oidc_policy = var.is_production ? github_oidc_production_policy : github_oidc_non_production_policy
+}
+
+module "github_oidc_roles" {
+  count       = var.github_oidc_enabled ? 1 : 0
+  source      = "./modules/github_oidc_roles"
+  name        = "reporting-gh-actions-run-reports"
+  description = "Run OPG reports"
+  repository  = var.github_oidc_repository
+
+  custom_policy_documents = local.github_oidc_policy
+}
+
+
+# OIDC polices
+# Used to get uptime stats
+data "aws_iam_policy_document" "uptime_metrics" {
+  version = "2012-10-17"
+
+  statement {
+    sid    = "CloudwatchMetrics"
+    effect = "Allow"
+    actions = [
+      "cloudwatch:GetMetricData",
+      "cloudwatch:GetMetricStatistics",
+      "cloudwatch:ListMetrics"
+    ]
+    resources = ["*"]
+  }
+}
+
+# Used to get cost data
+data "aws_iam_policy_document" "cost_data" {
+  version = "2012-10-17"
+
+  statement {
+    sid    = "CostExplorer"
+    effect = "Allow"
+    actions = [
+      "ce:get*"
+    ]
+    resources = ["*"]
+  }
+}

--- a/github_oidc_roles.tf
+++ b/github_oidc_roles.tf
@@ -6,7 +6,7 @@ locals {
   github_oidc_non_production_policy = [
     data.aws_iam_policy_document.cost_data.json
   ]
-  github_oidc_policy = var.is_production ? github_oidc_production_policy : github_oidc_non_production_policy
+  github_oidc_policy = var.is_production ? local.github_oidc_production_policy : local.github_oidc_non_production_policy
 }
 
 module "github_oidc_roles" {

--- a/github_oidc_roles.tf
+++ b/github_oidc_roles.tf
@@ -15,7 +15,7 @@ module "github_oidc_role_cost_data" {
 # OIDC role for fetching cloudwatch metrics relating to uptime checks
 # Only added for production accounts
 module "github_oidc_role_uptime_data" {
-  count       = locals.add_uptime_oidc ? 1 : 0
+  count       = local.add_uptime_oidc ? 1 : 0
   source      = "./modules/github_oidc_roles"
   name        = "gh-actions-uptime-metrics"
   description = "Run OPG uptime reports"

--- a/github_oidc_roles.tf
+++ b/github_oidc_roles.tf
@@ -9,7 +9,7 @@ module "github_oidc_role_cost_data" {
   description = "Run OPG costs reports"
   repository  = var.github_oidc_repository
 
-  custom_policy_documents = data.aws_iam_policy_document.cost_metrics.json
+  custom_policy_documents = [data.aws_iam_policy_document.cost_metrics.json]
 }
 
 # OIDC role for fetching cloudwatch metrics relating to uptime checks
@@ -21,7 +21,7 @@ module "github_oidc_role_uptime_data" {
   description = "Run OPG uptime reports"
   repository  = var.github_oidc_repository
 
-  custom_policy_documents = data.aws_iam_policy_document.uptime_metrics.json
+  custom_policy_documents = [data.aws_iam_policy_document.uptime_metrics.json]
 }
 
 # OIDC polices

--- a/modules/github_oidc_roles/main.tf
+++ b/modules/github_oidc_roles/main.tf
@@ -1,0 +1,78 @@
+locals {
+  auth_domain = "token.actions.githubusercontent.com"
+  org_name    = "ministryofjustice"
+  branch_and_main_sub_list = [
+    "repo:${local.org_name}/${var.repository}:pull_request",
+    "repo:${local.org_name}/${var.repository}:ref:refs/heads/*"
+  ]
+  main_sub_list = [
+    "repo:${local.org_name}/${var.repository}:ref:refs/heads/main"
+  ]
+  environment_sub_list = [
+    "repo:${local.org_name}/${var.repository}:environment:${var.github_environment}"
+  ]
+
+  # Defaults to main and branch. Can be overriden with variables main_only or github_environment
+  sub_list       = var.main_only == true ? local.main_sub_list : local.branch_and_main_sub_list
+  final_sub_list = var.github_environment == "" ? local.sub_list : local.environment_sub_list
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "github_oidc_assume_role" {
+  version = "2012-10-17"
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.auth_domain}"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.auth_domain}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "${local.auth_domain}:sub"
+      values   = local.final_sub_list
+    }
+  }
+}
+
+# Role to create
+resource "aws_iam_role" "oidc" {
+  name               = var.name
+  assume_role_policy = data.aws_iam_policy_document.github_oidc_assume_role.json
+}
+
+# Roles the OIDC role is allowed to assume
+data "aws_iam_policy_document" "oidc_assume_roles" {
+  count = length(var.assumable_roles) == 0 ? 0 : 1
+  statement {
+    sid     = "StsAssume"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    resources = var.assumable_roles
+  }
+}
+
+
+data "aws_iam_policy_document" "combined" {
+  source_policy_documents = concat(
+    var.custom_policy_documents,
+    length(var.assumable_roles) == 0 ? [] : [data.aws_iam_policy_document.oidc_assume_roles[0].json],
+  )
+}
+
+resource "aws_iam_role_policy" "oidc" {
+  name   = var.name
+  role   = aws_iam_role.oidc.name
+  policy = data.aws_iam_policy_document.combined.json
+}

--- a/modules/github_oidc_roles/main.tf
+++ b/modules/github_oidc_roles/main.tf
@@ -1,20 +1,10 @@
 locals {
   auth_domain = "token.actions.githubusercontent.com"
   org_name    = "ministryofjustice"
-  branch_and_main_sub_list = [
+  permission_list = [
     "repo:${local.org_name}/${var.repository}:pull_request",
     "repo:${local.org_name}/${var.repository}:ref:refs/heads/*"
   ]
-  main_sub_list = [
-    "repo:${local.org_name}/${var.repository}:ref:refs/heads/main"
-  ]
-  environment_sub_list = [
-    "repo:${local.org_name}/${var.repository}:environment:${var.github_environment}"
-  ]
-
-  # Defaults to main and branch. Can be overriden with variables main_only or github_environment
-  sub_list       = var.main_only == true ? local.main_sub_list : local.branch_and_main_sub_list
-  final_sub_list = var.github_environment == "" ? local.sub_list : local.environment_sub_list
 }
 
 data "aws_caller_identity" "current" {}
@@ -40,7 +30,7 @@ data "aws_iam_policy_document" "github_oidc_assume_role" {
     condition {
       test     = "ForAnyValue:StringLike"
       variable = "${local.auth_domain}:sub"
-      values   = local.final_sub_list
+      values   = local.permission_list
     }
   }
 }

--- a/modules/github_oidc_roles/main.tf
+++ b/modules/github_oidc_roles/main.tf
@@ -41,7 +41,7 @@ resource "aws_iam_role" "oidc" {
 data "aws_iam_policy_document" "oidc_assume_roles" {
   count = length(var.assumable_roles) == 0 ? 0 : 1
   statement {
-    sid     = "StsAssume"
+    sid     = "OIDCStsAssume"
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 

--- a/modules/github_oidc_roles/main.tf
+++ b/modules/github_oidc_roles/main.tf
@@ -5,7 +5,8 @@ locals {
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "github_oidc_assume_role" {
-  version = "2012-10-17"
+  policy_id = "OIDCAssumeRole"
+  version   = "2012-10-17"
 
   statement {
     sid     = "AllowGitHubOIDCToAssumeRoleViaWebIdentity"

--- a/modules/github_oidc_roles/main.tf
+++ b/modules/github_oidc_roles/main.tf
@@ -1,10 +1,5 @@
 locals {
   auth_domain = "token.actions.githubusercontent.com"
-  org_name    = "ministryofjustice"
-  permission_list = [
-    "repo:${local.org_name}/${var.repository}:pull_request",
-    "repo:${local.org_name}/${var.repository}:ref:refs/heads/*"
-  ]
 }
 
 data "aws_caller_identity" "current" {}
@@ -30,7 +25,7 @@ data "aws_iam_policy_document" "github_oidc_assume_role" {
     condition {
       test     = "ForAnyValue:StringLike"
       variable = "${local.auth_domain}:sub"
-      values   = local.permission_list
+      values   = var.permissions
     }
   }
 }

--- a/modules/github_oidc_roles/main.tf
+++ b/modules/github_oidc_roles/main.tf
@@ -8,6 +8,7 @@ data "aws_iam_policy_document" "github_oidc_assume_role" {
   version = "2012-10-17"
 
   statement {
+    sid     = "AllowGitHubOIDCToAssumeRoleViaWebIdentity"
     effect  = "Allow"
     actions = ["sts:AssumeRoleWithWebIdentity"]
 

--- a/modules/github_oidc_roles/outputs.tf
+++ b/modules/github_oidc_roles/outputs.tf
@@ -1,0 +1,4 @@
+output "aws_iam_role" {
+  description = "AWS IAM OIDC role"
+  value       = aws_iam_role.oidc
+}

--- a/modules/github_oidc_roles/variables.tf
+++ b/modules/github_oidc_roles/variables.tf
@@ -24,15 +24,3 @@ variable "custom_policy_documents" {
   description = "Policy documents to add to the role"
   default     = []
 }
-
-variable "main_only" {
-  type        = bool
-  description = "Whether role can only be called from main branch"
-  default     = false
-}
-
-variable "github_environment" {
-  type        = string
-  description = "If you use environment then it overrides other config"
-  default     = ""
-}

--- a/modules/github_oidc_roles/variables.tf
+++ b/modules/github_oidc_roles/variables.tf
@@ -1,8 +1,3 @@
-variable "repository" {
-  type        = string
-  description = "The slug of the github repository"
-}
-
 variable "name" {
   type        = string
   description = "The name of the role. Used for both policy and role"
@@ -23,4 +18,10 @@ variable "custom_policy_documents" {
   type        = list(any)
   description = "Policy documents to add to the role"
   default     = []
+}
+
+
+variable "permissions" {
+  type        = list(string)
+  description = "List of github permissions to scope the role to"
 }

--- a/modules/github_oidc_roles/variables.tf
+++ b/modules/github_oidc_roles/variables.tf
@@ -1,0 +1,38 @@
+variable "repository" {
+  type        = string
+  description = "The slug of the github repository"
+}
+
+variable "name" {
+  type        = string
+  description = "The name of the role. Used for both policy and role"
+}
+
+variable "description" {
+  type        = string
+  description = "Description of the role"
+}
+
+variable "assumable_roles" {
+  type        = list(string)
+  description = "List of assumable roles"
+  default     = []
+}
+
+variable "custom_policy_documents" {
+  type        = list(any)
+  description = "Policy documents to add to the role"
+  default     = []
+}
+
+variable "main_only" {
+  type        = bool
+  description = "Whether role can only be called from main branch"
+  default     = false
+}
+
+variable "github_environment" {
+  type        = string
+  description = "If you use environment then it overrides other config"
+  default     = ""
+}

--- a/modules/github_oidc_roles/versions.tf
+++ b/modules/github_oidc_roles/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+  required_version = ">= 1.0.0"
+}

--- a/roles.tf
+++ b/roles.tf
@@ -6,35 +6,6 @@ module "viewer" {
   custom_policy_json = var.viewer_custom_policy_json
 }
 
-module "billing" {
-  source             = "./modules/default_roles"
-  name               = "billing"
-  user_arns          = var.user_arns.billing
-  base_policy_arn    = var.billing_base_policy_arn
-  custom_policy_json = var.billing_custom_policy_json
-}
-
-data "aws_iam_policy_document" "aws_cost_explorer_access_for_billing" {
-  statement {
-    sid    = "AllowCostExplorerGet"
-    effect = "Allow"
-    actions = [
-      "ce:get*"
-    ]
-    resources = ["*"]
-  }
-}
-
-resource "aws_iam_policy" "aws_cost_explorer_access_for_billing" {
-  name        = "CostExporerAccessForBillingRole"
-  description = "Allow Cost Explorer API Get"
-  policy      = data.aws_iam_policy_document.aws_cost_explorer_access_for_billing.json
-}
-
-resource "aws_iam_role_policy_attachment" "aws_cost_explorer_access_for_billing" {
-  role       = module.billing.aws_iam_role.name
-  policy_arn = aws_iam_policy.aws_cost_explorer_access_for_billing.arn
-}
 
 module "operator" {
   source                  = "./modules/default_roles"
@@ -70,32 +41,4 @@ module "ci" {
   user_arns          = var.user_arns.ci
   base_policy_arn    = var.ci_base_policy_arn
   custom_policy_json = var.ci_custom_policy_json
-}
-
-
-data "aws_iam_policy_document" "cloudwatch_reporting_policy" {
-  statement {
-    sid    = "AllowCloudWatchReports"
-    effect = "Allow"
-    actions = [
-      "cloudwatch:GetMetricData",
-      "cloudwatch:GetMetricStatistics",
-      "cloudwatch:ListMetrics",
-    ]
-    resources = ["*"]
-  }
-}
-
-resource "aws_iam_policy" "cloudwatch_reporting" {
-  name        = "cloudwatch_metrics_policy"
-  description = "Policy to allow access to only metric information from cloudwatch"
-  policy      = data.aws_iam_policy_document.cloudwatch_reporting_policy.json
-}
-
-module "cloudwatch_reporting" {
-  count           = local.cloudwatch_reporting_role_enabled == true ? 1 : 0
-  source          = "./modules/default_roles"
-  name            = "cloudwatch-reporting-ci"
-  user_arns       = var.user_arns.cloudwatch_reporting
-  base_policy_arn = aws_iam_policy.cloudwatch_reporting.arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -53,15 +53,6 @@ variable "breakglass_custom_policy_json" {
   default = ""
 }
 
-variable "billing_base_policy_arn" {
-  type    = string
-  default = "arn:aws:iam::aws:policy/job-function/Billing"
-}
-
-variable "billing_custom_policy_json" {
-  type    = string
-  default = ""
-}
 
 variable "ci_base_policy_arn" {
   type    = string
@@ -138,12 +129,10 @@ variable "viewer_custom_policy_json" {
 
 variable "user_arns" {
   type = object({
-    view                 = list(string)
-    operation            = list(string)
-    breakglass           = list(string)
-    ci                   = list(string)
-    billing              = list(string)
-    cloudwatch_reporting = list(string)
+    view       = list(string)
+    operation  = list(string)
+    breakglass = list(string)
+    ci         = list(string)
   })
 
 }
@@ -314,9 +303,6 @@ variable "github_oidc_enabled" {
 locals {
   aws_cost_anomaly_notifications_enabled = var.aws_slack_notifications_enabled && var.aws_slack_cost_anomaly_notification_channel != "" ? true : false
   aws_health_notifications_enabled       = var.aws_slack_notifications_enabled && var.aws_slack_health_notification_channel != "" ? true : false
-
-  # locals for cloudwatch reporting role
-  cloudwatch_reporting_role_enabled = length(var.user_arns.cloudwatch_reporting) > 0 ? true : false
 
   # Locals to control provisioning of Modernisation Platform Provisioned Services in new accounts.
   cloudtrail_enabled          = !var.modernisation_platform_account

--- a/variables.tf
+++ b/variables.tf
@@ -300,6 +300,12 @@ variable "github_oidc_enabled" {
   description = "Enable an oidc provider in the account for use within github actions. Will create a stored query for the access log."
 }
 
+variable "github_oidc_repository" {
+  type        = string
+  default     = "opg-reports"
+  description = "Source repository slug where oidc calls will be made from. Default (opg-reports)"
+}
+
 locals {
   aws_cost_anomaly_notifications_enabled = var.aws_slack_notifications_enabled && var.aws_slack_cost_anomaly_notification_channel != "" ? true : false
   aws_health_notifications_enabled       = var.aws_slack_notifications_enabled && var.aws_slack_health_notification_channel != "" ? true : false

--- a/variables.tf
+++ b/variables.tf
@@ -300,14 +300,6 @@ variable "github_oidc_enabled" {
   description = "Enable an oidc provider in the account for use within github actions. Will create a stored query for the access log."
 }
 
-variable "github_oidc_permissions" {
-  type        = list(string)
-  description = "Permissions to scope the oidc role to"
-  default = [
-    "repo:ministryofjustice/opg-reports:pull_request",
-    "repo:ministryofjustice/opg-reports:ref:refs/heads/*"
-  ]
-}
 
 locals {
   aws_cost_anomaly_notifications_enabled = var.aws_slack_notifications_enabled && var.aws_slack_cost_anomaly_notification_channel != "" ? true : false

--- a/variables.tf
+++ b/variables.tf
@@ -300,10 +300,13 @@ variable "github_oidc_enabled" {
   description = "Enable an oidc provider in the account for use within github actions. Will create a stored query for the access log."
 }
 
-variable "github_oidc_repository" {
-  type        = string
-  default     = "opg-reports"
-  description = "Source repository slug where oidc calls will be made from. Default (opg-reports)"
+variable "github_oidc_permissions" {
+  type        = list(string)
+  description = "Permissions to scope the oidc role to"
+  default = [
+    "repo:ministryofjustice/opg-reports:pull_request",
+    "repo:ministryofjustice/opg-reports:ref:refs/heads/*"
+  ]
 }
 
 locals {


### PR DESCRIPTION
- remove `cloudwatch_reporting` and `billing` from `user_arns`
  - these were only used for reporting tooling, so remove them to reduce permissions
- remove billing and cloudwatch related permissions and iam
- add oidc roles for cost data and uptime perms