### PR TITLE
MLPAB-2499  - Abort multipart uploads after 7 days #major

### DIFF
--- a/modules/cloudtrail/s3.tf
+++ b/modules/cloudtrail/s3.tf
@@ -3,7 +3,7 @@ resource "aws_s3_bucket" "cloudtrail" {
 }
 
 resource "aws_s3_bucket_logging" "cloudtrail" {
-  bucket        = aws_s3_bucket.bucket.id
+  bucket        = aws_s3_bucket.cloudtrail.id
   target_bucket = var.s3_access_logging_bucket_name
   target_prefix = "log/${aws_s3_bucket.cloudtrial.id}/"
 }
@@ -19,7 +19,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "cloudtrail" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
-  bucket = aws_s3_bucket.bucket.id
+  bucket = aws_s3_bucket.cloudtrail.id
 
   rule {
     status = "Enabled"

--- a/modules/cloudtrail/s3.tf
+++ b/modules/cloudtrail/s3.tf
@@ -5,7 +5,7 @@ resource "aws_s3_bucket" "cloudtrail" {
 resource "aws_s3_bucket_logging" "cloudtrail" {
   bucket        = aws_s3_bucket.cloudtrail.id
   target_bucket = var.s3_access_logging_bucket_name
-  target_prefix = "log/${aws_s3_bucket.cloudtrial.id}/"
+  target_prefix = "log/${aws_s3_bucket.cloudtrail.id}/"
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "cloudtrail" {


### PR DESCRIPTION
Cloudtrail S3 bucket
- refactor to address deprecated options
- add lifecycle to abort multipart uploads after 7 days
Config S3 buckets
- refactor to address deprecated options
- add lifecycle to abort multipart uploads after 7 days
S3 Access Logging S3 buckets
- refactor to address deprecated options
- add lifecycle to abort multipart uploads after 7 days

This update requires importing the resources that have already been created.

Here is a a set of import blocks for a single account. Replace the id;s with the correct bucket names for your accounts

```hcl
# development account imports
# cloudtrail bucket
import {
  to = module.development.module.cloudtrail[0].aws_s3_bucket_lifecycle_configuration.bucket
  id = "cloudtrail-bucket-name"
}

import {
  to = module.development.module.cloudtrail[0].aws_s3_bucket_logging.cloudtrail
  id = "cloudtrail-bucket-name"
}

import {
  to = module.development.module.cloudtrail[0].aws_s3_bucket_server_side_encryption_configuration.cloudtrail
  id = "cloudtrail-bucket-name"
}

#config buckets
import {
  to = module.development.module.eu-west-1.module.aws_config[0].aws_s3_bucket_acl.config
  id = "config-eu-west-1-bucket,private"
}

import {
  to = module.development.module.eu-west-1.module.aws_config[0].aws_s3_bucket_lifecycle_configuration.config
  id = "config-eu-west-1-bucket"
}

import {
  to = module.development.module.eu-west-1.module.aws_config[0].aws_s3_bucket_logging.config
  id = "config-eu-west-1-bucket"
}

import {
  to = module.development.module.eu-west-1.module.aws_config[0].aws_s3_bucket_server_side_encryption_configuration.config
  id = "config-eu-west-1-bucket"
}

import {
  to = module.development.module.eu-west-1.module.aws_config[0].aws_s3_bucket_versioning.config
  id = "config-eu-west-1-bucket"
}

import {
  to = module.development.module.eu-west-2.module.aws_config[0].aws_s3_bucket_acl.config
  id = "config-eu-west-2-bucket,private"
}

import {
  to = module.development.module.eu-west-2.module.aws_config[0].aws_s3_bucket_lifecycle_configuration.config
  id = "config-eu-west-2-bucket"
}

import {
  to = module.development.module.eu-west-2.module.aws_config[0].aws_s3_bucket_logging.config
  id = "config-eu-west-2-bucket"
}

import {
  to = module.development.module.eu-west-2.module.aws_config[0].aws_s3_bucket_server_side_encryption_configuration.config
  id = "config-eu-west-2-bucket"
}

import {
  to = module.development.module.eu-west-2.module.aws_config[0].aws_s3_bucket_versioning.config
  id = "config-eu-west-2-bucket"
}

# access logging bucket
import {
  to = module.development.module.eu-west-1.aws_s3_bucket_lifecycle_configuration.s3_access_logging
  id = "s3-access-logs-bucket-eu-west-1"
}

import {
  to = module.development.module.eu-west-1.aws_s3_bucket_server_side_encryption_configuration.s3_access_logging
  id = "s3-access-logs-bucket-eu-west-1"
}

import {
  to = module.development.module.eu-west-1.aws_s3_bucket_versioning.s3_access_logging
  id = "s3-access-logs-bucket-eu-west-1"
}

import {
  to = module.development.module.eu-west-2.aws_s3_bucket_lifecycle_configuration.s3_access_logging
  id = "s3-access-logs-bucket-eu-west-2"
}

import {
  to = module.development.module.eu-west-2.aws_s3_bucket_server_side_encryption_configuration.s3_access_logging
  id = "s3-access-logs-bucket-eu-west-2"
}

import {
  to = module.development.module.eu-west-2.aws_s3_bucket_versioning.s3_access_logging
  id = "s3-access-logs-bucket-eu-west-2"
}
```



