### PR TITLE
MLPAB-2915 - Fix reference to view only role

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -44,7 +44,7 @@ variable "breakglass_base_policy_arn" {
 
 variable "data_access_base_policy_arn" {
   type    = string
-  default = "arn:aws:iam::aws:policy/ViewOnlyAccess"
+  default = "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"
 }
 
 variable "breakglass_create_instance_profile" {


### PR DESCRIPTION
# Purpose

Unable to apply previous tag as the ARN for the view only policy was incorrect

Fixes MLPAB-2915

## Approach

- use job-function view only policy 

## Learning

- https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ViewOnlyAccess.html