### PR TITLE
DDLS-635 add onboarding role

### DIFF
--- a/examples/development_account/main.tf
+++ b/examples/development_account/main.tf
@@ -19,12 +19,18 @@ data "aws_iam_group" "viewers" {
   provider   = aws.identity
 }
 
+data "aws_iam_group" "onboarding" {
+  group_name = "onboarding"
+  provider   = aws.identity
+}
+
 locals {
   user_arns = {
     breakglass  = concat(data.aws_iam_group.breakglass.users[*].arn, data.aws_iam_group.breakglass_product.users[*].arn)
     ci          = [aws_iam_user.ci_user.arn]
     operation   = data.aws_iam_group.operators.users[*].arn
     data_access = data.aws_iam_group.operators.users[*].arn
+    onboarding  = data.aws_iam_group.onboarding.users[*].arn
     view        = data.aws_iam_group.viewers.users[*].arn
   }
 }
@@ -50,6 +56,8 @@ module "development" {
   user_arns                                 = local.user_arns
   aws_security_hub_enabled                  = true
   aws_config_enabled                        = true
+  has_onboarding_role                       = true
+
   providers = {
     aws           = aws.development_eu_west_1
     aws.eu-west-2 = aws.development_eu_west_2

--- a/examples/full_example/main.tf
+++ b/examples/full_example/main.tf
@@ -18,18 +18,24 @@ data "aws_iam_group" "viewers" {
   provider   = aws.identity
 }
 
+data "aws_iam_group" "onboarding" {
+  group_name = "onboarding"
+  provider   = aws.identity
+}
+
 locals {
   user_arns = {
     breakglass  = concat(data.aws_iam_group.breakglass.users[*].arn, data.aws_iam_group.breakglass_product.users[*].arn)
     ci          = [aws_iam_user.ci_user.arn]
     operation   = data.aws_iam_group.operators.users[*].arn
     data_access = data.aws_iam_group.operators.users[*].arn
+    onboarding  = data.aws_iam_group.onboarding.users[*].arn
     view        = data.aws_iam_group.viewers.users[*].arn
 
   }
 }
 
-# Description: Full confuguration of an AWS account
+# Description: Full configuration of an AWS account
 module "full" {
   source                                       = "git@github.com:ministryofjustice/opg-terraform-aws-account.git?ref=v5.2.0"
   account_name                                 = "full"
@@ -76,6 +82,7 @@ module "full" {
   user_arns                                    = local.user_arns
   viewer_base_policy_arn                       = "arn:aws:iam::aws:policy/ReadOnlyAccess"
   viewer_custom_policy_json                    = ""
+  has_onboarding_role                          = false
 
   providers = {
     aws           = aws.production_eu_west_1

--- a/examples/production_account/main.tf
+++ b/examples/production_account/main.tf
@@ -18,12 +18,18 @@ data "aws_iam_group" "viewers" {
   provider   = aws.identity
 }
 
+data "aws_iam_group" "onboarding" {
+  group_name = "onboarding"
+  provider   = aws.identity
+}
+
 locals {
   user_arns = {
     breakglass  = concat(data.aws_iam_group.breakglass.users[*].arn, data.aws_iam_group.breakglass_product.users[*].arn)
     ci          = [aws_iam_user.ci_user.arn]
     operation   = data.aws_iam_group.operators.users[*].arn
     data_access = data.aws_iam_group.operators.users[*].arn
+    onboarding  = data.aws_iam_group.onboarding.users[*].arn
     view        = data.aws_iam_group.viewers.users[*].arn
   }
 }

--- a/roles.tf
+++ b/roles.tf
@@ -40,6 +40,7 @@ module "breakglass" {
 }
 
 module "data_access" {
+  count                   = length(var.user_arns.data_access) > 0 ? 1 : 0
   source                  = "./modules/default_roles"
   name                    = "data-access"
   user_arns               = var.user_arns.data_access

--- a/roles.tf
+++ b/roles.tf
@@ -1,3 +1,12 @@
+module "onboarding" {
+  count              = var.has_onboarding_role && length(var.user_arns.onboarding) > 0 ? 1 : 0
+  source             = "./modules/default_roles"
+  name               = "onboarding"
+  user_arns          = var.user_arns.onboarding
+  base_policy_arn    = var.onboarding_base_policy_arn
+  custom_policy_json = var.onboarding_custom_policy_json
+}
+
 module "viewer" {
   source             = "./modules/default_roles"
   name               = "viewer"

--- a/variables.tf
+++ b/variables.tf
@@ -129,12 +129,29 @@ variable "viewer_custom_policy_json" {
   default = ""
 }
 
+variable "onboarding_base_policy_arn" {
+  type    = string
+  default = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+variable "onboarding_custom_policy_json" {
+  type    = string
+  default = ""
+}
+
+variable "has_onboarding_role" {
+  type        = bool
+  default     = false
+  description = "Whether the account has an onboarding role (only for development accounts)"
+}
+
 variable "user_arns" {
   type = object({
     view        = list(string)
     operation   = list(string)
     breakglass  = list(string)
     data_access = list(string)
+    onboarding  = list(string)
     ci          = list(string)
   })
 }


### PR DESCRIPTION
# Purpose

Onboarding role for new developer/devops so they can't access too much of our estate initially

DDLS-635

## Approach

Added a new role in a similar way to the others but have put a flag on it as we only want the role in development accounts. 

## Learning

NA