### PR TITLE
fix version in submodule to be a minimum version, not a specific version

### DIFF
--- a/modules/kms_key_multi_region/versions.tf
+++ b/modules/kms_key_multi_region/versions.tf
@@ -9,5 +9,5 @@ terraform {
       ]
     }
   }
-  required_version = "1.12.1"
+  required_version = ">= 1.12.1"
 }


### PR DESCRIPTION
# Purpose

Set minimum version for terraform, not a specific version when used in a sub-module

