### PR TITLE
set expire days in s3 access logging bucket to match id name

### DIFF
--- a/modules/region/s3_access_logging.tf
+++ b/modules/region/s3_access_logging.tf
@@ -22,7 +22,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "s3_access_logging" {
     }
 
     expiration {
-      days = 365
+      days = 490
     }
   }
 


### PR DESCRIPTION
# Purpose

Lifecycle rule ID says expire after 490 days but is set to 365

Fixes <TICKET-REF>

## Approach

- adjust to 490 days