### PR TITLE
Change semver range to >= for better external compatability

### DIFF
--- a/modules/global/versions.tf
+++ b/modules/global/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.99.0"
+      version = ">= 5.99.0"
       configuration_aliases = [
         aws.eu_west_1,
         aws.eu_west_2,

--- a/modules/kms_key_multi_region/versions.tf
+++ b/modules/kms_key_multi_region/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.99.0"
+      version = ">= 5.99.0"
       configuration_aliases = [
         aws.eu_west_1,
         aws.eu_west_2,

--- a/modules/macie_regional/versions.tf
+++ b/modules/macie_regional/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.99.0"
+      version = ">= 5.99.0"
       configuration_aliases = [
         aws.region,
       ]

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.38"
+      version = ">= 5.38"
       configuration_aliases = [
         aws.eu-west-2,
         aws.global,


### PR DESCRIPTION
Renovate on this repo is incrementing the range when using `~> 5.x` notation to specific regions so upstream usage can't move beyond that value without this repo getting updated

Swapping to use `>=` so less updates needed on this repo