### PR TITLE
Fix macie outputs when enabled or paused

### DIFF
--- a/modules/global/outputs.tf
+++ b/modules/global/outputs.tf
@@ -1,7 +1,7 @@
 output "eu_west_1_macie_findings_encryption_key" {
-  value = var.macie_enabled ? module.macie_findings_encryption_key.eu_west_1_target_key : null
+  value = var.macie_enabled ? module.macie_findings_encryption_key[0].eu_west_1_target_key : null
 }
 
 output "eu_west_2_macie_findings_encryption_key" {
-  value = var.macie_enabled ? module.macie_findings_encryption_key.eu_west_2_target_key : null
+  value = var.macie_enabled ? module.macie_findings_encryption_key[0].eu_west_2_target_key : null
 }


### PR DESCRIPTION
# Purpose

Setting aws_macie2_status to "ENABLED" or "PAUSED" results in an error because the macie kms keys have a count and therefore are a tuple

## Approach

- values for outputs are a tuple
