### PR TITLE
MLPAB-3214 - Do not auto resolve CIS alarms

### DIFF
--- a/modules/security_hub/cis_foundation_controls.tf
+++ b/modules/security_hub/cis_foundation_controls.tf
@@ -167,7 +167,6 @@ resource "aws_cloudwatch_metric_alarm" "toggled_control" {
   actions_enabled     = each.value.actions_enabled
   alarm_name          = each.value.metric_name
   alarm_actions       = [aws_sns_topic.cis_aws_foundations_standard.arn]
-  ok_actions          = [aws_sns_topic.cis_aws_foundations_standard.arn]
   alarm_description   = each.value.alarm_description
   namespace           = "CISLogMetrics"
   metric_name         = each.value.metric_name


### PR DESCRIPTION
# Purpose

Stop automatically resolving alarms related to CIS security hub standards

Fixes MLPAB-3214, OWCP-70

## Approach

- remove ok actions from CIS alarms so they don't auto resolve

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm#ok_actions-1
