### PR TITLE
MLPAB-3234 - enable resource tagging standard

### DIFF
--- a/modules/security_hub/aws_resource_tagging_standard.tf
+++ b/modules/security_hub/aws_resource_tagging_standard.tf
@@ -1,4 +1,9 @@
 resource "aws_securityhub_standards_subscription" "resource_tagging" {
   depends_on    = [aws_securityhub_account.main]
   standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/aws-resource-tagging-standard/v/1.0.0"
+  timeouts {
+    create = "10m"
+    delete = "10m"
+  }
+
 }

--- a/modules/security_hub/aws_resource_tagging_standard.tf
+++ b/modules/security_hub/aws_resource_tagging_standard.tf
@@ -1,4 +1,4 @@
-resource "aws_securityhub_standards_subscription" "cis" {
+resource "aws_securityhub_standards_subscription" "resource_tagging" {
   depends_on    = [aws_securityhub_account.main]
   standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/aws-resource-tagging-standard/v/1.0.0"
 }

--- a/modules/security_hub/aws_resource_tagging_standard.tf
+++ b/modules/security_hub/aws_resource_tagging_standard.tf
@@ -1,0 +1,4 @@
+resource "aws_securityhub_standards_subscription" "cis" {
+  depends_on    = [aws_securityhub_account.main]
+  standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/aws-resource-tagging-standard/v/1.0.0"
+}

--- a/modules/security_hub/aws_resource_tagging_standard.tf
+++ b/modules/security_hub/aws_resource_tagging_standard.tf
@@ -5,5 +5,4 @@ resource "aws_securityhub_standards_subscription" "resource_tagging" {
     create = "10m"
     delete = "10m"
   }
-
 }


### PR DESCRIPTION
# Purpose

Briefly describe the purpose of the change, and/or link to the JIRA ticket for context

Fixes MLPAB-3234

## Approach

- add security hub subscription for resource tagging standard

## Learning

- https://docs.aws.amazon.com/securityhub/latest/userguide/standards-tagging.html
- https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/securityhub_standards_subscription