### PR TITLE
increase timeout for CIS 3.0.0 subscription as creation takes longer than the default sometimes

### DIFF
--- a/modules/security_hub/cis_foundation_controls_3_0.tf
+++ b/modules/security_hub/cis_foundation_controls_3_0.tf
@@ -2,4 +2,9 @@ resource "aws_securityhub_standards_subscription" "cis_3_0" {
   count         = var.cis_3_0_subscription_enabled ? 1 : 0
   depends_on    = [aws_securityhub_account.main]
   standards_arn = "arn:aws:securityhub:${data.aws_region.current.region}::standards/cis-aws-foundations-benchmark/v/3.0.0"
+
+  timeouts {
+    create = "7m"
+    delete = "7m"
+  }
 }


### PR DESCRIPTION
https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts

https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/securityhub_standards_subscription#timeouts