### PR TITLE
LPAL-1665 account module aws config s3 bucket enforce bucket owner instead of using ACLs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,26 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 ---
-    repos:
-      - repo: https://github.com/pre-commit/pre-commit-hooks
-        rev: v2.0.0
-        hooks:
-          - id: trailing-whitespace
-          - id: end-of-file-fixer
-          - id: check-yaml
-      - repo: https://github.com/antonbabenko/pre-commit-terraform
-        rev: v1.44.0
-        hooks:
-          - id: terraform_fmt
-          - id: terraform_docs_without_aggregate_type_defaults
+  repos:
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v2.0.0
+      hooks:
+        - id: trailing-whitespace # trims trailing whitespace.
+        - id: end-of-file-fixer # ensures that a file is either empty, or ends with one newline.
+        - id: check-added-large-files # prevents giant files from being committed.
+          args: [ "--maxkb=20480" ]
+        - id: check-case-conflict # checks for files that would conflict in case-insensitive filesystems.
+        - id: check-json # Attempts to load all json files to verify syntax.
+        - id: check-merge-conflict # checks for files that contain merge conflict strings.
+        - id: check-yaml # checks yaml files for parseable syntax.
+        - id: detect-private-key # detects the presence of private keys.
+        - id: mixed-line-ending # replaces or checks mixed line ending.
+          args: [ "--fix=auto" ]
+        - id: no-commit-to-branch
+          args:
+          - --branch=main
+    - repo: https://github.com/antonbabenko/pre-commit-terraform
+      rev: v1.44.0
+      hooks:
+        - id: terraform_fmt
+        - id: terraform_docs_without_aggregate_type_defaults

--- a/modules/config/s3.tf
+++ b/modules/config/s3.tf
@@ -12,9 +12,12 @@ resource "aws_s3_bucket_versioning" "config" {
   }
 }
 
-resource "aws_s3_bucket_acl" "config" {
+resource "aws_s3_bucket_ownership_controls" "config" {
   bucket = aws_s3_bucket.config.id
-  acl    = "private"
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
 }
 
 resource "aws_s3_bucket_logging" "config" {


### PR DESCRIPTION
# Purpose

Newly created AWS Config buckets have bucket owner enforced, and cannot add ACLs. This arrangement seems preferred to using ACLs and allowing the object push to set access controls for Config related objects.

Fixes LPAL-1665

## Approach

- remove private acl resource
- add ownership control set to "BucketOwnerEnforced"

## Learning

- https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html
- https://docs.aws.amazon.com/AmazonS3/latest/userguide/acls.html
