### PR TITLE
LPAL-1769 - add log insights query for failed console logins

### DIFF
--- a/modules/cis_queries/main.tf
+++ b/modules/cis_queries/main.tf
@@ -46,6 +46,18 @@ fields @timestamp, eventName, requestParameters.roleName, requestParameters.poli
 EOF
 }
 
+resource "aws_cloudwatch_query_definition" "cis_3_6" {
+  name = "CIS-Queries/CIS-3.6-ConsoleAuthenticationFailure"
+
+  log_group_names = [var.cloudtrail_log_group_name]
+
+  query_string = <<EOF
+fields @timestamp, sourceIPAddress, userIdentity.userName, eventName, responseElements.ConsoleLogin
+| filter eventName = "ConsoleLogin" and responseElements.ConsoleLogin = "Failure"
+| sort @timestamp desc
+EOF
+}
+
 resource "aws_cloudwatch_query_definition" "cis_3_8" {
   name = "CIS-Queries/CIS-3.8-S3BucketPolicyChanges"
 


### PR DESCRIPTION
# Purpose

We have an alarm but no query for failed console logins

Fixes LPAL-1769