### PR TITLE
UML-4335: Pin pre-commit, github actions to version, renovate update

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,29 +7,35 @@
   ],
   "branchPrefix": "renovate-",
   "commitMessageAction": "Renovate",
+  "minimumReleaseAge": "7 days",
   "labels": [
-      "Renovate"
+    "Renovate"
   ],
   "packageRules": [
     {
       "groupName": "Minor and Patch Updates",
-      "matchPackagePatterns": ["*"],
+      "matchPackagePatterns": [
+        "*"
+      ],
       "matchUpdateTypes": [
         "minor",
         "patch"
       ],
-      "stabilityDays": 5,
-      "addLabels": ["minor-and-patch"]
+      "addLabels": [
+        "minor-and-patch"
+      ]
     },
     {
       "groupName": "Major Updates",
-      "matchPackagePatterns": ["*"],
+      "matchPackagePatterns": [
+        "*"
+      ],
       "matchUpdateTypes": [
         "major"
       ],
-      "stabilityDays": 5,
-      "addLabels": ["major"]
+      "addLabels": [
+        "major"
+      ]
     }
-
   ]
 }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,14 +17,14 @@ jobs:
     name: Lint Terraform
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: "Parse terraform version"
         id: tf_version
-        uses: ministryofjustice/opg-github-actions/actions/terraform-version@b605e1e2c94b399e8139c4c2be2c8730700e0004
+        uses: ministryofjustice/opg-github-actions/actions/terraform-version@ceeda9d30ec7f6705c819d0b7664b9a79df99a3b #v4.8.0
         with:
           terraform_directory: "./"
       - name: "Setup terraform [version: ${{ steps.tf_version.outputs.version }}]"
-        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: ${{ steps.tf_version.outputs.version }}
       - name: terraform fmt
@@ -35,12 +35,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
             fetch-depth: "0"
       - name: "Generate semver tag and release"
         id: semver_tag
-        uses: ministryofjustice/opg-github-actions/actions/semver@b605e1e2c94b399e8139c4c2be2c8730700e0004
+        uses: ministryofjustice/opg-github-actions/actions/semver@ceeda9d30ec7f6705c819d0b7664b9a79df99a3b #v4.8.0
         with:
           prerelease: ${{ github.ref != 'refs/heads/main' }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 ---
   repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v2.0.0
+      rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
       hooks:
         - id: trailing-whitespace # trims trailing whitespace.
         - id: end-of-file-fixer # ensures that a file is either empty, or ends with one newline.
@@ -20,7 +20,7 @@
           args:
           - --branch=main
     - repo: https://github.com/antonbabenko/pre-commit-terraform
-      rev: v1.44.0
+      rev: d0e12caebb2ab0ee8bf98181c8bfe9702bca103d  # frozen: v1.105.0
       hooks:
         - id: terraform_fmt
         - id: terraform_docs_without_aggregate_type_defaults


### PR DESCRIPTION
# Purpose

Pinning pre-commit hooks to SHA's, updating renovate from deprecated `stabilityDays` to `minimumReleaseAge` and adding version to github actions pins so that renovate can update in future

Fixes UML-4335

## Approach

Explain how your code addresses the purpose of the change

## Learning

Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered.
