### PR TITLE
LPAL-1954 - Resolve validation warnings

### DIFF
--- a/modules/cloudtrail/s3.tf
+++ b/modules/cloudtrail/s3.tf
@@ -25,6 +25,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
     status = "Enabled"
     id     = "archive-after-30-days"
 
+    filter {
+      prefix = ""
+    }
+
     noncurrent_version_transition {
       noncurrent_days = 30
       storage_class   = "GLACIER"
@@ -38,6 +42,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
 
   rule {
     id = "abort-incomplete-multipart-upload"
+
+    filter {
+      prefix = ""
+    }
 
     abort_incomplete_multipart_upload {
       days_after_initiation = 7

--- a/modules/cloudtrail/s3.tf
+++ b/modules/cloudtrail/s3.tf
@@ -25,9 +25,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
     status = "Enabled"
     id     = "archive-after-30-days"
 
-    filter {
-      prefix = ""
-    }
+    filter {}
 
     noncurrent_version_transition {
       noncurrent_days = 30
@@ -43,9 +41,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
   rule {
     id = "abort-incomplete-multipart-upload"
 
-    filter {
-      prefix = ""
-    }
+    filter {}
 
     abort_incomplete_multipart_upload {
       days_after_initiation = 7

--- a/modules/config/s3.tf
+++ b/modules/config/s3.tf
@@ -42,9 +42,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "config" {
     status = "Enabled"
     id     = "expire-after-490-days"
 
-    filter {
-      prefix = ""
-    }
+    filter {}
 
     noncurrent_version_expiration {
       noncurrent_days = 10
@@ -58,9 +56,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "config" {
   rule {
     id = "abort-incomplete-multipart-upload"
 
-    filter {
-      prefix = ""
-    }
+    filter {}
 
     abort_incomplete_multipart_upload {
       days_after_initiation = 7

--- a/modules/config/s3.tf
+++ b/modules/config/s3.tf
@@ -1,7 +1,7 @@
 data "aws_region" "current" {}
 
 resource "aws_s3_bucket" "config" {
-  bucket        = "config-${data.aws_region.current.name}-${var.account_name}-${var.product}-opg"
+  bucket        = "config-${data.aws_region.current.region}-${var.account_name}-${var.product}-opg"
   force_destroy = true
 }
 
@@ -23,7 +23,7 @@ resource "aws_s3_bucket_ownership_controls" "config" {
 resource "aws_s3_bucket_logging" "config" {
   bucket        = aws_s3_bucket.config.id
   target_bucket = var.s3_access_logging_bucket_name
-  target_prefix = "log/config-${data.aws_region.current.name}-${var.account_name}-${var.product}-opg"
+  target_prefix = "log/config-${data.aws_region.current.region}-${var.account_name}-${var.product}-opg"
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "config" {

--- a/modules/config/s3.tf
+++ b/modules/config/s3.tf
@@ -42,6 +42,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "config" {
     status = "Enabled"
     id     = "expire-after-490-days"
 
+    filter {
+      prefix = ""
+    }
+
     noncurrent_version_expiration {
       noncurrent_days = 10
     }
@@ -53,6 +57,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "config" {
 
   rule {
     id = "abort-incomplete-multipart-upload"
+
+    filter {
+      prefix = ""
+    }
 
     abort_incomplete_multipart_upload {
       days_after_initiation = 7

--- a/modules/macie_regional/s3.tf
+++ b/modules/macie_regional/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "bucket" {
-  bucket        = "macie-${data.aws_region.current.name}-${var.account_name}-${var.product}-opg"
+  bucket        = "macie-${data.aws_region.current.region}-${var.account_name}-${var.product}-opg"
   force_destroy = true
   provider      = aws.region
 }
@@ -96,8 +96,8 @@ data "aws_iam_policy_document" "bucket" {
       test     = "ArnLike"
       variable = "aws:SourceArn"
       values = [
-        "arn:aws:macie2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:export-configuration:*",
-        "arn:aws:macie2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:classification-job/*"
+        "arn:aws:macie2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:export-configuration:*",
+        "arn:aws:macie2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:classification-job/*"
       ]
     }
   }
@@ -124,8 +124,8 @@ data "aws_iam_policy_document" "bucket" {
       test     = "ArnLike"
       variable = "aws:SourceArn"
       values = [
-        "arn:aws:macie2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:export-configuration:*",
-        "arn:aws:macie2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:classification-job/*"
+        "arn:aws:macie2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:export-configuration:*",
+        "arn:aws:macie2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:classification-job/*"
       ]
     }
   }

--- a/modules/macie_regional/s3.tf
+++ b/modules/macie_regional/s3.tf
@@ -37,9 +37,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
     status = "Enabled"
     id     = "expire-after-490-days"
 
-    filter {
-      prefix = ""
-    }
+    filter {}
 
     noncurrent_version_expiration {
       noncurrent_days = 10
@@ -53,9 +51,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
   rule {
     id = "abort-incomplete-multipart-upload"
 
-    filter {
-      prefix = ""
-    }
+    filter {}
 
     abort_incomplete_multipart_upload {
       days_after_initiation = 7

--- a/modules/macie_regional/s3.tf
+++ b/modules/macie_regional/s3.tf
@@ -36,9 +36,15 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
   rule {
     status = "Enabled"
     id     = "expire-after-490-days"
+
+    filter {
+      prefix = ""
+    }
+
     noncurrent_version_expiration {
       noncurrent_days = 10
     }
+
     expiration {
       days = 490
     }
@@ -46,6 +52,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
 
   rule {
     id = "abort-incomplete-multipart-upload"
+
+    filter {
+      prefix = ""
+    }
 
     abort_incomplete_multipart_upload {
       days_after_initiation = 7

--- a/modules/region/s3_access_logging.tf
+++ b/modules/region/s3_access_logging.tf
@@ -16,9 +16,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "s3_access_logging" {
     status = "Enabled"
     id     = "expire-after-490-days"
 
-    filter {
-      prefix = ""
-    }
+    filter {}
 
     transition {
       days          = 30
@@ -33,9 +31,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "s3_access_logging" {
   rule {
     id = "abort-incomplete-multipart-upload"
 
-    filter {
-      prefix = ""
-    }
+    filter {}
 
     abort_incomplete_multipart_upload {
       days_after_initiation = 7

--- a/modules/region/s3_access_logging.tf
+++ b/modules/region/s3_access_logging.tf
@@ -16,6 +16,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "s3_access_logging" {
     status = "Enabled"
     id     = "expire-after-490-days"
 
+    filter {
+      prefix = ""
+    }
+
     transition {
       days          = 30
       storage_class = "GLACIER"
@@ -28,6 +32,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "s3_access_logging" {
 
   rule {
     id = "abort-incomplete-multipart-upload"
+
+    filter {
+      prefix = ""
+    }
 
     abort_incomplete_multipart_upload {
       days_after_initiation = 7

--- a/modules/region/s3_access_logging.tf
+++ b/modules/region/s3_access_logging.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "s3_access_logging" {
-  bucket = "s3-access-logs-opg-${var.product}-${var.account_name}-${data.aws_region.current.name}"
+  bucket = "s3-access-logs-opg-${var.product}-${var.account_name}-${data.aws_region.current.region}"
 }
 
 resource "aws_s3_bucket_versioning" "s3_access_logging" {

--- a/modules/security_hub/aws_foundational_security_best_practices.tf
+++ b/modules/security_hub/aws_foundational_security_best_practices.tf
@@ -1,5 +1,5 @@
 locals {
-  fsbp_standard_controls_arn_path = "arn:aws:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:control/aws-foundational-security-best-practices/v/1.0.0"
+  fsbp_standard_controls_arn_path = "arn:aws:securityhub:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:control/aws-foundational-security-best-practices/v/1.0.0"
 }
 
 resource "aws_securityhub_standards_control" "iam_6_hardware_mfa_should_be_enabled_for_the_root_user" {

--- a/modules/security_hub/aws_resource_tagging_standard.tf
+++ b/modules/security_hub/aws_resource_tagging_standard.tf
@@ -1,6 +1,6 @@
 resource "aws_securityhub_standards_subscription" "resource_tagging" {
   depends_on    = [aws_securityhub_account.main]
-  standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/aws-resource-tagging-standard/v/1.0.0"
+  standards_arn = "arn:aws:securityhub:${data.aws_region.current.region}::standards/aws-resource-tagging-standard/v/1.0.0"
   timeouts {
     create = "10m"
     delete = "10m"

--- a/modules/security_hub/cis_foundation_controls_1_2.tf
+++ b/modules/security_hub/cis_foundation_controls_1_2.tf
@@ -13,7 +13,7 @@ resource "aws_securityhub_standards_control" "cis_1_14_ensure_hardware_mfa_is_en
   ]
 }
 locals {
-  cis_standard_controls_arn_path             = "arn:aws:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:control/cis-aws-foundations-benchmark/v/1.2.0"
+  cis_standard_controls_arn_path             = "arn:aws:securityhub:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:control/cis-aws-foundations-benchmark/v/1.2.0"
   cis_foundation_control_3_10_custom_enabled = var.cis_1_2_foundation_control_3_10_custom_filter == "" ? false : true
   cis_controls = {
     cis_3_1_unauthorised_api_calls = {

--- a/modules/slack_notifications/main.tf
+++ b/modules/slack_notifications/main.tf
@@ -1,6 +1,6 @@
 module "aws_cost_notifier" {
   count                     = var.aws_cost_anomaly_notifications_enabled ? 1 : 0
-  source                    = "git@github.com:ministryofjustice/opg-aws-cost-notifier.git"
+  source                    = "git@github.com:ministryofjustice/opg-aws-cost-notifier.git?ref=v1.34.0"
   account_name              = var.account_name
   ecr_repository_url        = data.aws_ecr_repository.cost_notifier_lambda.repository_url
   failed_invocation_sns_arn = aws_sns_topic.slack_notification_failures.arn
@@ -16,7 +16,7 @@ module "aws_cost_notifier" {
 
 module "aws_health_notifier" {
   count                     = var.aws_health_notifications_enabled ? 1 : 0
-  source                    = "git@github.com:ministryofjustice/opg-aws-health-notifier.git"
+  source                    = "git@github.com:ministryofjustice/opg-aws-health-notifier.git?ref=v1.29.0"
   account_name              = var.account_name
   ecr_repository_url        = data.aws_ecr_repository.health_notifier_lambda.repository_url
   failed_invocation_sns_arn = aws_sns_topic.slack_notification_failures.arn

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.38"
+      version = ">= 6"
       configuration_aliases = [
         aws.eu-west-2,
         aws.global,

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6"
+      version = ">= 6.0.0"
       configuration_aliases = [
         aws.eu-west-2,
         aws.global,


### PR DESCRIPTION
# Purpose

Resolve warnings when using the module

Fixes LPAL-1954

## Approach

- update aws provider version requirement to >=6.0.0
- replace `name` with `region` for the aws_region data source to fix deprecation warning
- add empty filter for s3 lifecycle rules to fix Invalid Attribute Combination warning
- pin notifier modules

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-6-upgrade#data-source-aws_region
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration
