### PR TITLE
DDLS-1487 add CI boundaried role option to accounts repo

### DIFF
--- a/modules/ci_roles/main.tf
+++ b/modules/ci_roles/main.tf
@@ -1,0 +1,267 @@
+data "aws_caller_identity" "current" {}
+
+############################
+# CI role with boundary enabled
+############################
+module "ci" {
+  source                   = "../default_roles"
+  name                     = "${var.service}-ci-boundary"
+  user_arns                = var.user_arns
+  base_policy_arn          = var.base_policy_arn
+  custom_policy_json       = var.custom_policy_json
+  permissions_boundary_arn = aws_iam_policy.ci_boundary.arn
+}
+
+############################
+# Boundary Local Variables
+############################
+locals {
+  ci_role_name = "${var.service}-ci-boundary"
+  ci_role_arn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.ci_role_name}"
+
+  protected_principal_names = ["ci", "operator", "viewer", "breakglass"]
+
+  protected_role_arns = flatten([
+    for n in local.protected_principal_names : [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${n}",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*/${n}",
+    ]
+  ])
+}
+
+############################
+# Permissions boundary policy
+############################
+resource "aws_iam_policy" "ci_boundary" {
+  name        = "${var.service}-ci-boundary"
+  description = "Permission boundary for ${var.service} CI role"
+  policy      = data.aws_iam_policy_document.ci_boundary_policy.json
+}
+
+data "aws_iam_policy_document" "ci_boundary_policy" {
+  statement {
+    sid    = "AllowBaselineSelectedServices"
+    effect = "Allow"
+
+    actions   = var.boundary
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "AllowIamReadMetaData"
+    effect = "Allow"
+    actions = [
+      "iam:Get*",
+      "iam:List*"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "DenyBoundaryRemovalOnAnyPrincipal"
+    effect = "Deny"
+    actions = [
+      "iam:DeleteRolePermissionsBoundary",
+      "iam:DeleteUserPermissionsBoundary"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "ProtectBoundaryPolicies"
+    effect = "Deny"
+    actions = [
+      "iam:CreatePolicyVersion",
+      "iam:SetDefaultPolicyVersion",
+      "iam:DeletePolicy",
+      "iam:DeletePolicyVersion",
+      "iam:TagPolicy",
+      "iam:UntagPolicy",
+      "iam:AttachRolePolicy",
+      "iam:DetachRolePolicy",
+      "iam:AttachUserPolicy",
+      "iam:DetachUserPolicy",
+      "iam:AttachGroupPolicy",
+      "iam:DetachGroupPolicy"
+    ]
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${var.service}-ci-boundary",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${var.service}-non-ci-boundary"
+    ]
+  }
+
+  statement {
+    sid    = "RequireBoundaryOnCreateRole"
+    effect = "Deny"
+
+    actions   = ["iam:CreateRole"]
+    resources = ["*"]
+
+    condition {
+      test     = "StringNotEquals"
+      variable = "iam:PermissionsBoundary"
+      values   = [aws_iam_policy.non_ci_boundary.arn]
+    }
+  }
+
+  statement {
+    sid    = "RequireBoundaryOnPutRolePermissionsBoundary"
+    effect = "Deny"
+
+    actions   = ["iam:PutRolePermissionsBoundary"]
+    resources = ["*"]
+
+    condition {
+      test     = "StringNotEquals"
+      variable = "iam:PermissionsBoundary"
+      values   = [aws_iam_policy.non_ci_boundary.arn]
+    }
+  }
+
+  statement {
+    sid    = "DenyAllUserModification"
+    effect = "Deny"
+
+    not_actions = [
+      "iam:Get*",
+      "iam:List*"
+    ]
+
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/*"
+    ]
+  }
+
+  statement {
+    sid    = "DenyModificationProtectedRoles"
+    effect = "Deny"
+
+    not_actions = [
+      "iam:Get*",
+      "iam:List*"
+    ]
+    resources = local.protected_role_arns
+  }
+
+  statement {
+    sid    = "DenyAccessKeyLifecycle"
+    effect = "Deny"
+    actions = [
+      "iam:CreateAccessKey",
+      "iam:UpdateAccessKey",
+      "iam:DeleteAccessKey"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "DenyConsoleCreds"
+    effect = "Deny"
+    actions = [
+      "iam:CreateLoginProfile",
+      "iam:UpdateLoginProfile",
+      "iam:DeleteLoginProfile"
+    ]
+    resources = ["*"]
+  }
+
+  # Defence-in-depth: CI role itself is read-only (boundary-level)
+  statement {
+    sid    = "CiRoleSelfReadOnly"
+    effect = "Deny"
+    not_actions = [
+      "iam:Get*",
+      "iam:List*"
+    ]
+    resources = [local.ci_role_arn]
+  }
+}
+
+############################
+# Permissions boundary policy for roles created by CI
+############################
+resource "aws_iam_policy" "non_ci_boundary" {
+  name        = "${var.service}-non-ci-boundary"
+  description = "Permission boundary for roles created by CI"
+  policy      = data.aws_iam_policy_document.non_ci_boundary_policy.json
+}
+
+data "aws_iam_policy_document" "non_ci_boundary_policy" {
+  statement {
+    sid    = "AllowSelectedServices"
+    effect = "Allow"
+
+    actions = var.boundary
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "AllowIamRead"
+    effect = "Allow"
+    actions = [
+      "iam:Get*",
+      "iam:List*"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "DenyECRMutating"
+    effect = "Deny"
+    actions = [
+      "ecr:PutImage",
+      "ecr:BatchDeleteImage",
+      "ecr:DeleteRepository",
+      "ecr:DeleteRepositoryPolicy",
+      "ecr:SetRepositoryPolicy",
+      "ecr:PutLifecyclePolicy",
+      "ecr:DeleteLifecyclePolicy",
+      "ecr:StartImageScan",
+      "ecr:TagResource",
+      "ecr:UntagResource",
+      "ecr:PutImageTagMutability",
+      "ecr:ReplicateImage"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "DenyIamWrite"
+    effect = "Deny"
+
+    actions = [
+      "iam:Create*",
+      "iam:Update*",
+      "iam:Delete*",
+      "iam:Put*",
+      "iam:Attach*",
+      "iam:Detach*"
+    ]
+    resources = ["*"]
+  }
+}
+
+############################
+# Guardrails policy attached to CI role
+############################
+
+resource "aws_iam_role_policy" "ci_guardrails" {
+  name   = "${var.service}-ci-guardrails"
+  role   = module.ci.aws_iam_role.id
+  policy = data.aws_iam_policy_document.ci_guardrails.json
+}
+
+data "aws_iam_policy_document" "ci_guardrails" {
+  statement {
+    sid    = "CiRoleSelfReadOnlyInline"
+    effect = "Deny"
+
+    not_actions = [
+      "iam:Get*",
+      "iam:List*"
+    ]
+
+    resources = [module.ci.aws_iam_role.arn]
+  }
+}

--- a/modules/ci_roles/outputs.tf
+++ b/modules/ci_roles/outputs.tf
@@ -1,0 +1,4 @@
+output "aws_iam_role" {
+  description = "CI role"
+  value       = module.ci.aws_iam_role
+}

--- a/modules/ci_roles/variables.tf
+++ b/modules/ci_roles/variables.tf
@@ -1,0 +1,25 @@
+variable "service" {
+  type        = string
+  description = "The name of the service"
+  default     = "webops"
+}
+
+variable "user_arns" {
+  type    = list(string)
+  default = []
+}
+
+variable "boundary" {
+  type    = list(string)
+  default = []
+}
+
+variable "custom_policy_json" {
+  type    = string
+  default = ""
+}
+
+variable "base_policy_arn" {
+  type    = string
+  default = ""
+}

--- a/modules/ci_roles/versions.tf
+++ b/modules/ci_roles/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+  required_version = ">= 1.0.0"
+}

--- a/modules/default_roles/main.tf
+++ b/modules/default_roles/main.tf
@@ -13,14 +13,20 @@ variable "custom_policy_json" {
   default = ""
 }
 
+variable "permissions_boundary_arn" {
+  type    = string
+  default = ""
+}
+
 variable "create_instance_profile" {
   type    = bool
   default = false
 }
 
 resource "aws_iam_role" "role" {
-  name               = var.name
-  assume_role_policy = var.create_instance_profile ? data.aws_iam_policy_document.instance_profile[0].json : data.aws_iam_policy_document.role.json
+  name                 = var.name
+  assume_role_policy   = var.create_instance_profile ? data.aws_iam_policy_document.instance_profile[0].json : data.aws_iam_policy_document.role.json
+  permissions_boundary = var.permissions_boundary_arn != "" ? var.permissions_boundary_arn : null
 }
 
 resource "aws_iam_instance_profile" "role" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,5 +15,9 @@ output "aws_sns_topic_slack_notification_failures" {
 }
 
 output "ci_iam_role" {
-  value = length(var.user_arns.ci) > 0 ? module.ci[0].aws_iam_role : null
+  value = length(var.user_arns.ci) > 0 && var.ci_unboundaried ? module.ci[0].aws_iam_role : null
+}
+
+output "ci_iam_role_boundaried" {
+  value = length(var.user_arns.ci) > 0 && var.ci_boundaried ? module.ci_boundaried[0].aws_iam_role : null
 }

--- a/roles.tf
+++ b/roles.tf
@@ -60,9 +60,18 @@ moved {
 }
 
 module "ci" {
-  count              = length(var.user_arns.ci) > 0 ? 1 : 0
+  count              = length(var.user_arns.ci) > 0 && var.ci_classic_enabled ? 1 : 0
   source             = "./modules/default_roles"
   name               = "${var.product}-ci"
+  user_arns          = var.user_arns.ci
+  base_policy_arn    = var.ci_base_policy_arn
+  custom_policy_json = var.ci_custom_policy_json
+}
+
+module "ci_boundaried" {
+  count              = length(var.user_arns.ci) > 0 && var.ci_boundaried_enabled ? 1 : 0
+  source             = "./modules/ci_roles"
+  service            = var.product
   user_arns          = var.user_arns.ci
   base_policy_arn    = var.ci_base_policy_arn
   custom_policy_json = var.ci_custom_policy_json

--- a/variables.tf
+++ b/variables.tf
@@ -145,6 +145,16 @@ variable "has_onboarding_role" {
   description = "Whether the account has an onboarding role (only for development accounts)"
 }
 
+variable "ci_boundaried_enabled" {
+  type    = bool
+  default = false
+}
+
+variable "ci_classic_enabled" {
+  type    = bool
+  default = true
+}
+
 variable "user_arns" {
   type = object({
     view        = list(string)


### PR DESCRIPTION
This PR creates reusable module that creates a boundaried CI role. The role has the following restrictions:

Allows only pre-approved service actions (var.boundary) across all resources
Allows read-only IAM access (Get/List) for visibility and introspection
Prevents removal of permissions boundaries from any role or user
Protects both boundary policies from deletion, version changes, tagging, or (de)attachment
Forces all created roles to use the non‑CI boundary
Prevents setting any other permissions boundary on roles
Blocks all non-read operations on IAM users (effectively no user management at all)
Blocks modification of protected roles (ci, operator, viewer, breakglass), while still allowing read-only access
Disables access key lifecycle actions (no creating/updating/deleting access keys)
Disables console credential management (no login profiles)
Makes the CI role itself read-only (can inspect but not modify itself or its policies)
It then is forced to add the boundary for non CI users to any role it creates. That boundary can't modify any users or roles. I think this is fine as we shouldn't really be having service roles that can modify other roles and users.

We can see it in action here with screenshots: https://opgtransform.atlassian.net/browse/DDLS-1417

Currently, we will allow both boundaried and non boundaried to facilitate the switch over needed.