### PR TITLE
SP-3844 - Disable Root MFA Security Hub Control as per ADR #minor

### DIFF
--- a/modules/security_hub/cis_foundation_controls_3_0.tf
+++ b/modules/security_hub/cis_foundation_controls_3_0.tf
@@ -8,3 +8,17 @@ resource "aws_securityhub_standards_subscription" "cis_3_0" {
     delete = "7m"
   }
 }
+
+locals {
+  cis_3_0_standard_controls_arn_path = "arn:aws:securityhub:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:control/cis-aws-foundations-benchmark/v/3.0.0"
+}
+
+resource "aws_securityhub_standards_control" "cis_3_0_iam_6_hardware_mfa_should_be_enabled_for_the_root_user" {
+  count                 = var.cis_3_0_subscription_enabled ? 1 : 0
+  standards_control_arn = "${local.cis_3_0_standard_controls_arn_path}/1.6"
+  control_status        = "DISABLED"
+  disabled_reason       = "See ADR https://docs.opg.service.justice.gov.uk/documentation/adrs/adr-004.html#adr-004-no-hardware-mfa-key-for-root-account"
+  depends_on = [
+    aws_securityhub_account.main
+  ]
+}


### PR DESCRIPTION
As Per - https://docs.opg.service.justice.gov.uk/documentation/adrs/adr-004.html#adr-004-no-hardware-mfa-key-for-root-account

Account CSP's from the root account now also severely limit what can be done with the root user.